### PR TITLE
[Server] feature: projectId로 프로젝트의 상세페이지를 가져오는 기능 추가 (#56)

### DIFF
--- a/server/src/main/java/wap/web2/server/controller/ProjectController.java
+++ b/server/src/main/java/wap/web2/server/controller/ProjectController.java
@@ -1,10 +1,12 @@
 package wap.web2.server.controller;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import wap.web2.server.ouath2.security.CurrentUser;
 import wap.web2.server.payload.request.ProjectCreateRequest;
+import wap.web2.server.payload.response.ProjectDetailsResponse;
 import wap.web2.server.payload.response.ProjectsResponse;
 import wap.web2.server.payload.response.ProjectInfoResponse;
 import wap.web2.server.service.ProjectService;
@@ -65,5 +68,16 @@ public class ProjectController {
 
         projectService.save(fullRequest);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<?> getProject(@PathVariable Long projectId) {
+        Optional<ProjectDetailsResponse> projectDetails = projectService.getProjectDetails(projectId);
+
+        if(projectDetails.isPresent()) {
+            return ResponseEntity.ok(projectDetails.get());
+        }
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body("Project not found for id: " + projectId);
     }
 }

--- a/server/src/main/java/wap/web2/server/payload/response/ProjectDetailsResponse.java
+++ b/server/src/main/java/wap/web2/server/payload/response/ProjectDetailsResponse.java
@@ -1,0 +1,47 @@
+package wap.web2.server.payload.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import wap.web2.server.domain.Image;
+import wap.web2.server.domain.Project;
+import wap.web2.server.domain.TeamMember;
+import wap.web2.server.domain.TechStack;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProjectDetailsResponse {
+
+    private Long projectId;
+    private String title;
+    private String projectType;
+    private String content;
+    private String summary;
+    private Integer semester;
+    private Long vote;
+    private Integer projectYear;
+    private String thumbnail;
+    private List<TeamMember> teamMember;
+    private List<TechStack> techStack;
+    private List<Image> images;
+
+    public static ProjectDetailsResponse from(Project project) {
+        return ProjectDetailsResponse.builder()
+            .projectId(project.getProjectId())
+            .title(project.getTitle())
+            .projectType(project.getProjectType())
+            .content(project.getContent())
+            .summary(project.getSummary())
+            .semester(project.getSemester())
+            .vote(project.getVote())
+            .projectYear(project.getProjectYear())
+            .thumbnail(project.getThumbnail())
+            .teamMember(project.getTeamMembers())
+            .techStack(project.getTechStacks())
+            .images(project.getImages())
+            .build();
+    }
+}

--- a/server/src/main/java/wap/web2/server/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/service/ProjectService.java
@@ -3,12 +3,15 @@ package wap.web2.server.service;
 import java.io.IOException;
 import java.util.List;
 
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wap.web2.server.domain.Project;
 import wap.web2.server.payload.request.ProjectCreateRequest;
+import wap.web2.server.payload.response.ProjectDetailsResponse;
 import wap.web2.server.payload.response.ProjectInfoResponse;
 import wap.web2.server.repository.ProjectRepository;
 import wap.web2.server.util.AwsUtils;
@@ -40,5 +43,9 @@ public class ProjectService {
     public List<ProjectInfoResponse> getProjects(Long year, Long semester) {
         return projectRepository.findProjectsByYearAndSemester(year, semester)
             .stream().map(ProjectInfoResponse::from).toList();
+    }
+
+    public Optional<ProjectDetailsResponse> getProjectDetails(Long projectId) {
+        return projectRepository.findById(projectId).map(ProjectDetailsResponse::from);
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #56

## ✨ PR 세부 내용
- project/{projectId}에 접근하여 프로젝트의 상세페이지를 확인할 수 있다.
- 프로젝트의 상세페이지를 담는 Response를 생성하였다.

## 수정해야할 사항
- Project와 연관되어 있는 TeamMember를 불러올때 TeamMember의 Project 속성에서 불필요한 데이터까지 가져오게 된다.
<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간