### PR TITLE
feature : 수정페이지 이동 검증

### DIFF
--- a/server/src/main/java/wap/web2/server/controller/ProjectController.java
+++ b/server/src/main/java/wap/web2/server/controller/ProjectController.java
@@ -88,6 +88,19 @@ public class ProjectController {
             .body("Project not found for id: " + projectId);
     }
 
+    @GetMapping("/{projectId}/update")
+    public ResponseEntity<?> getProjectDetailsForUpdate(@PathVariable Long projectId, @CurrentUser UserPrincipal userPrincipal) {
+        try {
+            // 프로젝트 상세 정보를 가져오는 서비스 호출
+            ProjectDetailsResponse response = projectService.getProjectDetailsForUpdate(projectId, userPrincipal);
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        } catch (IllegalArgumentException ex) {
+            // 유효하지 않은 유저 ID
+            return ResponseEntity.status(403).body("수정 권한이 없습니다.");
+        }
+    }
+
+
     @PutMapping("{projectId}")
     public ResponseEntity<?> updateProject(@PathVariable Long projectId,
                                            @CurrentUser UserPrincipal userPrincipal,

--- a/server/src/main/java/wap/web2/server/exception/ResourceNotFoundException.java
+++ b/server/src/main/java/wap/web2/server/exception/ResourceNotFoundException.java
@@ -16,6 +16,10 @@ public class ResourceNotFoundException extends RuntimeException {
         this.fieldValue = fieldValue;
     }
 
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
     public String getResourceName() {
         return resourceName;
     }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #118 

## ✨ PR 세부 내용
 - 수정하기 버튼 클릭 : 로그인한 회원이 자기가 작성한 프로젝트 내용을 받아오고 이어서 수정할 수 있게 프로젝트 상세보기 내용을 get으로 전달
    - 회원이 작성한 프로젝트만 수정할 수 있어야 함으로 토큰 필요
    - 회원 자신이 작성한 프로젝트가 아닌데 수정을 시도하면 에러코드 : 403, body : 수정 권한이 없습니다.
<!-- 수정/추가한 내용을 적어주세요. -->

## 예외처리 관련 트러블슈팅
- get 요청의 경우, @CurrentUser가 null 값을 반환했더라도 메서드 내부에서 userPrincipal.getId()를 호출하려고 하므로 따로 user가 비었는지 검증 필요
- 나머지 http 메서드는 Spring Security가 기본적으로 잘못된 토큰을 감지하고 AuthenticationException을 발생시켜 클라이언트에게 401 Unauthorized를 반환.

## ⌛ 소요 시간
예외처리때문에 4시간