### PR TITLE
하나의 지원서로 여러 프로젝트에 지원하도록 변경

### DIFF
--- a/server/src/main/resources/templates/projects-application.html
+++ b/server/src/main/resources/templates/projects-application.html
@@ -671,19 +671,19 @@
 <div class="container">
     <div class="header">
         <h1>프로젝트 지원 시스템</h1>
-        <p>공통 지원서를 작성하고 원하는 프로젝트들에 한 번에 지원하세요!</p>
+        <p>지원서를 작성하고 원하는 프로젝트들에 한 번에 지원하세요!</p>
     </div>
 
     <!-- 공통 지원서 작성 섹션 -->
     <div class="common-application-section" id="commonApplicationSection">
         <div class="section-title">
-            📝 공통 지원서 작성
+            📝 지원서 작성
             <span class="status-indicator" id="applicationStatusIndicator">1</span>
         </div>
 
         <div id="applicationFormContainer">
             <div class="warning-message">
-                먼저 공통 지원서를 작성해주세요. 작성된 지원서로 여러 프로젝트에 지원할 수 있습니다.
+                먼저 지원서를 작성해주세요. 작성된 지원서로 여러 프로젝트에 지원할 수 있습니다.
             </div>
             <button class="create-application-btn" onclick="openApplicationModal()">
                 지원서 작성하기
@@ -760,11 +760,11 @@
     <span id="floatingCartCount">0</span>
 </div>
 
-<!-- 공통 지원서 작성 모달 -->
+<!-- 지원서 작성 모달 -->
 <div id="applicationModal" class="modal">
     <div class="modal-content">
         <span class="close" onclick="closeApplicationModal()">&times;</span>
-        <h2>공통 지원서 작성</h2>
+        <h2>지원서 작성</h2>
         <p>이 지원서로 선택한 모든 프로젝트에 지원됩니다.</p>
 
         <form id="commonApplicationForm">
@@ -869,7 +869,7 @@
         enableProjectSelection();
         closeApplicationModal();
 
-        alert('공통 지원서가 저장되었습니다! 이제 프로젝트를 선택할 수 있습니다.');
+        alert('지원서가 저장되었습니다! 이제 프로젝트를 선택할 수 있습니다.');
     }
 
     // 지원서 표시 업데이트
@@ -916,7 +916,7 @@
     // 프로젝트를 장바구니에 추가
     function addToCart(projectId, projectTitle) {
         if (!commonApplication) {
-            alert('먼저 공통 지원서를 작성해주세요.');
+            alert('먼저 지원서를 작성해주세요.');
             return;
         }
 
@@ -1045,7 +1045,7 @@
         }
 
         if (!commonApplication) {
-            alert('먼저 공통 지원서를 작성해주세요.');
+            alert('먼저 지원서를 작성해주세요.');
             return;
         }
 
@@ -1194,7 +1194,7 @@
         }
 
         if (!commonApplication) {
-            alert('공통 지원서가 작성되지 않았습니다.');
+            alert('지원서가 작성되지 않았습니다.');
             return;
         }
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- #288 

## ✨ PR 세부 내용
- 프로젝트마다 지원서를 작성하는 구조에서 하나의 지원 메시지로 여러 프로제트에 지원할 수 있도록 변경하였다.
- 지원서를 작성하기 전엔 프로젝트를 선택할 수 없다.

<img width="1193" height="921" alt="스크린샷 2025-09-04 오후 12 00 25" src="https://github.com/user-attachments/assets/efd412a2-38e9-4bde-a818-92fa6ec5cc5a" />

- 희망 직무와 지원 메시지를 작성하였다면 프로젝트를 선택할 수 있다.
<img width="1201" height="872" alt="image" src="https://github.com/user-attachments/assets/70ee4829-dada-4b02-8fb1-e54f270dea10" />


<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간
10m