### PR TITLE
fix: 모집 정보를 가져오고 맵화 하는 로직 변경

### DIFF
--- a/server/src/main/java/wap/web2/server/project/repository/ProjectRepository.java
+++ b/server/src/main/java/wap/web2/server/project/repository/ProjectRepository.java
@@ -23,5 +23,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Query("SELECT p FROM Project p WHERE p.projectYear = :year AND p.semester = :semester ORDER BY p.projectId DESC")
     List<Project> findProjectsByYearAndSemesterOrderByProjectIdDesc(@Param("year") Integer year,
                                                                     @Param("semester") Integer semester);
-    
+
+    List<Project> findAllBySemester(String semester);
 }


### PR DESCRIPTION


<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
- position별로 모집 정보를 가져올 때, 현재 학기에 열린 모든 프로젝트에 대해서 고려한다.
- 예를 들어 frontend를 1팀에서 뽑지 않았더라도 맵에는 cap(0)와 userIds(empty)가 저장된다.

## ⌛ 소요 시간