### PR TITLE
fix: 학기 초기화 버그 수정(#337)

### DIFF
--- a/client/src/components/ContentBox.js
+++ b/client/src/components/ContentBox.js
@@ -32,7 +32,7 @@ const ContentBox = () => {
   const apiUrl = `${process.env.REACT_APP_API_BASE_URL}/project/list`;
 
   useEffect(() => {
-    console.log("useEffect triggered. Fetching data for semester:", semesterFilter);
+
     const timeoutId = setTimeout(() => {
       setIsMounted(true); // 일정 시간 후에 마운트 상태 변경
     }, 700);
@@ -98,7 +98,6 @@ const ContentBox = () => {
 
   const handleSemesterChange = (year, semester) => {
     const newFilter = { year, semester };
-    console.log("Semester changed to:", newFilter);
     setSemesterFilter(newFilter); // 학기 필터 상태 변경
     setSearchParams({ projectYear: year, semester: semester });
     setYearAccordionOpen(false); // 드롭다운 닫기


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #337

## ✨ PR 세부 내용
1. `const currentYear = 2025`로 하드코딩 되어 있던 연도를 `Date`객체를 사용하여 해당연도를 반영하도록 하였습니다. 
추후에 Home 페이지에서 연도 선택 기능을 추가한다면, 이 부분을 아마 추가적으로 고쳐야할 것 같습니다....
2. 리엑트 라우터 라이브러리에 포함되어 있는 훅인 `useSearchParams`를 사용해서 쿼리 스트링으로 학기 상태 저장 후 가져올 수 있도록 수정하였습니다. 로컬에서 테스트해본 결과, 다른 페이지에서 다시 뒤로 돌아올 때 학기 필터 값이 그대로 유지가 잘되고 있었습니다!

지금은 쿼리스트링으로 문제를 해결 했지만 zustand 등 전역 상태 관리 라이브러리로도 쉽게 해결할 수 있는 문제였습니다.
 추후 전역 상태를 관리할 일이 많은 경우, zustand 도입도 생각해볼만한 것 같습니다. 
이 부분에 대해서 자세한 내용은 노션 트러블슈팅 확인해주세요!
> 트러블슈팅: https://www.notion.so/2024wap/27702f6b10fb80f48336cb07a19d7e93?source=copy_link
<img width="349" height="508" alt="image" src="https://github.com/user-attachments/assets/31974f6f-c70d-45f9-b089-e99fcc65f6db" />
로컬 테스트 결과



## ⌛ 소요 시간