### PR TITLE
chore: 뒤로가기 버튼 및 투표 페이지 메인 컬러 관련 디자인 변경

### DIFF
--- a/client/src/assets/Vote/ProjectVote.module.css
+++ b/client/src/assets/Vote/ProjectVote.module.css
@@ -6,6 +6,10 @@
   font-style: normal;
 }
 
+:root {
+  --primary: rgb(163, 175, 249);
+}
+
 .project_vote_form {
   max-width: 400px;
   height: 100%;
@@ -72,14 +76,36 @@
 }
 
 .selected {
-  border: 2px solid #02ff2e; /* 선택된 프로젝트의 테두리 색상 */
-  color: #02ff2e;
+  border: 2px solid var(--primary); /* 선택된 프로젝트의 테두리 색상 */
+  color: var(--primary);
 }
 
 .selected_result {
+  color: var(--primary); /* 1-3위 순위권 색상 */
+}
+
+/* 순위 번호의 기본 스타일 클래스 */
+/* 순위 번호의 '레이아웃' (여백, 글자 크기) - 색상 없음 */
+.rank_layout {
   margin-top: 10px;
   font-size: 18px;
-  color: #02ff2e;
+}
+
+.rank_default_color {
+  color: var(--primary);
+}
+/* 순위별 투명도 조절 클래스 */
+.rank_opacity_top3 {
+  opacity: 1; /* 1-3위: 100% */
+}
+.rank_opacity_4 {
+  opacity: 0.85; /* 4위: 85% */
+}
+.rank_opacity_5 {
+  opacity: 0.7; /* 5위: 70% */
+}
+.rank_opacity_other {
+  opacity: 0.5; /* 6위 이하: 50% */
 }
 
 .inform_box {
@@ -136,7 +162,7 @@
 }
 
 .project_vote_count {
-  color: #02ff2e;
+  color: var(--primary);
   font-size: 14px;
   flex-grow: 0; /* title은 추가 공간을 차지하지 않도록 설정 */
 }
@@ -154,7 +180,7 @@
 }
 
 .selected_title {
-  color: #02ff2e; /* 선택된 프로젝트의 테두리 색상 */
+  color: var(--primary); /* 선택된 프로젝트의 테두리 색상 */
 }
 
 .summary {

--- a/client/src/components/FloatingButton.js
+++ b/client/src/components/FloatingButton.js
@@ -15,7 +15,7 @@ const FloatingButton = () => {
         position: "fixed",
         bottom: "20px",
         left: "20px",
-        backgroundColor: "#02FF2E",
+        backgroundColor: "rgb(163,175,249)",
         color: "#2A2A2A",
         border: "none",
         borderRadius: "50%",

--- a/client/src/pages/VotePage.js
+++ b/client/src/pages/VotePage.js
@@ -72,9 +72,6 @@ const VotePage = () => {
 
       <Menu menuOpen={menuOpen} toggleMenu={toggleMenu} />
       <main>
-        {/* 이게 내가 사용해야할 코드임!! 지금 백엔드가 안되어있어서 임시방편으로
-        아래방법 선택함. */}
-        {/* {isOpen ? <VoteForm /> : <VoteResultPage />} */}
         {isOpen ? <VoteForm isVotedUser={isvotedUser} /> : <VoteResultPage />}
       </main>
       <FloatingButton />

--- a/client/src/pages/VoteResultPage.js
+++ b/client/src/pages/VoteResultPage.js
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
-import Cookies from "js-cookie";
-import { useNavigate } from "react-router-dom";
 import styles from "../assets/Vote/ProjectVote.module.css";
 
 // 투표 기간이 아닐 때 나타나는 페이지임.
@@ -82,7 +80,21 @@ const VoteResultPage = () => {
             actualRank++;
 
             const isTop3 = displayedRank <= 3;
-
+            // 순위에 따라 투명도 클래스 결정 
+            let opacityClass;
+            if (displayedRank <= 3) {
+              // 1, 2, 3위
+              opacityClass = styles.rank_opacity_top3;
+            } else if (displayedRank === 4) {
+              // 4위
+              opacityClass = styles.rank_opacity_4;
+            } else if (displayedRank === 5) {
+              // 5위
+              opacityClass = styles.rank_opacity_5;
+            } else {
+              // 6위 이하
+              opacityClass = styles.rank_opacity_other;
+            }
             return (
               <div
                 className={`${styles.project_list_box}`}
@@ -90,7 +102,11 @@ const VoteResultPage = () => {
               >
                 <div className={styles.inform_box}>
                   <div
-                    className={isTop3 ? styles.selected_result : ""}
+                    className={`
+                      ${styles.rank_layout}
+                      ${isTop3 ? styles.selected_result : styles.rank_default_color}
+                      ${opacityClass}
+                    `}
                     style={{ marginTop: 10, fontSize: 18 }}
                   >
                     {displayedRank}
@@ -109,7 +125,10 @@ const VoteResultPage = () => {
                     <p className={styles.summary}>{project.projectSummary}</p>
                   </div>
                   <div className={styles.project_result_form}>
-                    <div className={styles.project_vote_count}>
+                    <div className={`
+                        ${styles.project_vote_count}
+                        ${opacityClass}
+                      `}>
                       {project.voteCount} 득표
                     </div>
                     <div className={styles.project_vote_rate}>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #391 

## ✨ PR 세부 내용
<img width="468" height="926" alt="image" src="https://github.com/user-attachments/assets/3b3933a5-53c2-4745-835f-beb9de5092f1" />

1. 뒤로가기 플로팅 버튼과 투표 결과 페이지의 메인 컬러를 새로운 디자인에 맞게 변경하였습니다. (#02FF2E => rgb(163,175,249))
2. 순위 별로 클래스를 따로 부여하여 1~3순위의 경우 `opacity`값을 100%로, 이후로 점점 값이 낮아지도록 하였습니다.

<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간