### PR TITLE
modify: 팀빌딩 페이지에 접근할 수 없도록 변경

### DIFF
--- a/client/src/pages/menu/TeamBuildPage.js
+++ b/client/src/pages/menu/TeamBuildPage.js
@@ -18,12 +18,14 @@ function TeamBuildPage() {
       return;
     }
 
+    alert("현재 팀빌딩이 열려 있지 않습니다!");
+    navigate("/HomePage");
     // REACT_APP_API_BASE_URL 뒤에 슬래시가 중복되지 않도록 정리
     // const base = (process.env.REACT_APP_API_BASE_URL || "").replace(/\/+$/, "");
 
     // URL 파라미터로 token 전달
-    setMsg("이동 중...");
-    window.location.href = `${process.env.REACT_APP_API_BASE_URL}/team-build?token=${encodeURIComponent(token)}`;
+    // setMsg("이동 중...");
+    // window.location.href = `${process.env.REACT_APP_API_BASE_URL}/team-build?token=${encodeURIComponent(token)}`;
   }, [navigate]);
 
   return (


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #393 
## ✨ PR 세부 내용
<img width="325" height="129" alt="image" src="https://github.com/user-attachments/assets/28c21e2b-b8fb-4946-aab3-6eedea2800de" />

메뉴창에서 팀 빌딩 페이지 버튼을 누를 시 alert가 뜨면서 이동이 불가능 하도록 하였습니다.

`navigate(-1)`으로 이전 페이지로 되돌아가도록 하려고 했으나, 플레시 페이지로 계속 돌아가지는 문제가 있어 `navigate("/HomePage");`를 사용하여 우선 홈페이지로 이동하도록 수정하였습니다.

이 부분은 추후 이전페이지로 돌아갈 수 있도록 수정하겠습니다!
<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간