### PR TITLE
chore: 팀빌딩 결과 페이지 버튼 css를 다른페이지와 통일

### DIFF
--- a/client/src/assets/TeamBuildResult.module.css
+++ b/client/src/assets/TeamBuildResult.module.css
@@ -184,7 +184,6 @@ body {
   display: flex;
   gap: 7px;
 }
-
 .btn {
   padding: 8px 11px;
   border: 1px solid var(--border);
@@ -194,31 +193,14 @@ body {
   border-color: #fff;
   text-align: center;
   cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-.activeSort {
   background-color: var(--accent);
   border-color: var(--accent);
   color: var(--black);
   font-weight: 500;
-}
-
-.activeSort:hover {
-  background-color: var(--accent);
-  border-color: var(--accent);
-  color: var(--black);
-}
-
-.btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .activeSort {
@@ -357,6 +339,18 @@ body {
   border-color: #7f7f7f;
   color: #7f7f7f;
   font-weight: 600;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.copy:hover {
+  color: var(--text);
+  border-color: var(--text);
+}
+
+.copy:active {
+  color: var(--text);
+  border-color: var(--text);
+  background-color: var(--muted);
 }
 
 .empty {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->
##  📌 관련 이슈

- closed: #401

## ✨ PR 세부 내용
<img width="278" height="115" alt="image" src="https://github.com/user-attachments/assets/9da0e6cf-3fce-4189-97a0-b808227d7bd2" /> 

(명단 복사 버튼 hover한 경우)
1. 상단의 **팀명순/미배정** 버튼의 css에서 `transition` 속성을 추가하고, `.btn:hover`클래스의 배경색을 변경하여 다른 페이지의 버튼들과 통일 되도록 하였습니다.
2.  **명단 복사** 버튼의 css에 `hover`, `active` 클래스를 추가하여 구분감이 있도록 하였습니다.
3. 중복된 css 클래스들을 정리하였습니다
<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간