### PR TITLE
modify: 권한에 따른 메뉴 항목 숨김/표시 처리

### DIFF
--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -134,18 +134,20 @@ const Menu = ({ menuOpen, toggleMenu, userName }) => {
               </div>
             </div>
 
-            <div className="menu-section">
-              <h3 className="section-title">ADMINISTRATOR</h3>
-              <div className="menu-items">
-                <button
-                  className="menu-item"
-                  onClick={handleAdminNavigate}
-                >
-                  <span>임원진 페이지 Administrator Page</span>
-                  <span className="arrow"><FaChevronRight /></span>
-                </button>
+            {(userRole === "ROLE_ADMIN") &&
+              <div className="menu-section">
+                <h3 className="section-title">ADMINISTRATOR</h3>
+                <div className="menu-items">
+                  <button
+                    className="menu-item"
+                    onClick={handleAdminNavigate}
+                  >
+                    <span>임원진 페이지 Administrator Page</span>
+                    <span className="arrow"><FaChevronRight /></span>
+                  </button>
+                </div>
               </div>
-            </div>
+            }
 
             <div className="menu-section">
               <h3 className="section-title">VOTE</h3>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->
간단한 작업이라 따로 이슈 파지 않고 진행하였습니다.
## ✨ PR 세부 내용
`ROLE_ADMIN` 권한이 있는 경우에만 메뉴에서 어드민 페이지로 이동 버튼이 보이도록 변경하였습니다.
<img width="298" height="697" alt="image" src="https://github.com/user-attachments/assets/765486d9-7bcc-4f56-acd2-d7d31d7d2578" /><img width="302" height="699" alt="image" src="https://github.com/user-attachments/assets/75ffb8e2-fe8e-4fcf-a3c4-2ad667291f75" />
(좌: 로그인 X or 권한 X     /     우: 어드민 권한 O)

1. `menu.js`에서 userRole === "ROLE_ADMIN"의 값에 따라 어드민 페이지 섹션의 숨김/표시 여부를 결정하도록 변경하였습니다.
<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간