### PR TITLE
 feat: 어드민 페이지 사이드바 반응형 적용

### DIFF
--- a/client/src/assets/Admin/AdminPageLayout.module.css
+++ b/client/src/assets/Admin/AdminPageLayout.module.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  position: relative;
 }
 
 .main {
@@ -21,10 +22,15 @@
   gap: 38px;
   flex: 1;
   min-height: 0;
+  position: relative;
+}
+
+.sidebarWrapper {
+  display: block;
 }
 
 .contentsBox {
-  width: 1441px;
+  flex: 1;
   height: 100%;
   padding: 43px;
   border-radius: 56px;
@@ -37,6 +43,30 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.hamburger {
+  display: none;
+  cursor: pointer;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 30px;
+  height: 24px;
+}
+
+.hamburger span {
+  display: block;
+  height: 3px;
+  width: 100%;
+  background-color: #adadad;
+  border-radius: 3px;
 }
 
 .logo {
@@ -68,4 +98,71 @@
   line-height: 1;
   cursor: pointer;
   user-select: none;
+}
+
+.mobileSidebarOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+}
+
+.mobileSidebarContent {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 350px; /* 모바일 사이드바 너비 */
+  height: 100%;
+  background-color: #1a1a1a; /* 배경색 지정 */
+  padding: 30px;
+  box-sizing: border-box;
+  z-index: 1000;
+  box-shadow: 4px 0 15px rgba(0, 0, 0, 0.5);
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+/* --- 반응형 미디어 쿼리 (1024px 이하일 때 동작) --- */
+@media (max-width: 1024px) {
+  .container {
+    padding: 20px; /* 패딩 축소 */
+  }
+
+  /* 데스크탑 사이드바 숨김 */
+  .sidebarWrapper {
+    display: none;
+  }
+
+  /* 메뉴 버튼 표시 */
+  .hamburger {
+    display: flex;
+  }
+
+  /* 메인 갭 제거 */
+  .main {
+    gap: 0;
+  }
+
+  .contentsBox {
+    padding: 20px; /* 내부 패딩 축소 */
+    border-radius: 30px;
+  }
+
+  .logo {
+    font-size: 24px;
+  }
+  .adminUser {
+    font-size: 18px;
+  }
 }

--- a/client/src/assets/Admin/SideBar.module.css
+++ b/client/src/assets/Admin/SideBar.module.css
@@ -14,12 +14,14 @@
   display: flex;
   flex-direction: column;
   gap: 73px;
+  width: 100%;
 }
 
 .title {
-  width: 351px;
+  width: 100%;
   text-align: left;
   margin-top: 16px;
+  white-space: nowrap;
 }
 
 .eng {
@@ -35,10 +37,12 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  width: 100%;
 }
 
 .pageBtn button {
-  width: 292px;
+  width: 100%;
+  max-width: 292px;
   height: 66px;
 
   font-size: 20px;
@@ -57,6 +61,7 @@
   justify-content: flex-start;
   padding-left: 35px;
   gap: 20px;
+  box-sizing: border-box;
 }
 
 .pageBtn button svg {
@@ -71,4 +76,15 @@
 .active {
   background: var(--primary) !important;
   color: black !important;
+}
+
+@media (max-width: 1024px) {
+  .eng {
+    font-size: 25px;
+    font-weight: 600;
+  }
+
+  .kr {
+    font-size: 20px;
+  }
 }

--- a/client/src/components/Admin/AdminPageLayout.js
+++ b/client/src/components/Admin/AdminPageLayout.js
@@ -8,6 +8,8 @@ import Cookies from "js-cookie";
 const AdminPageLayout = () => {
     // 유저 이름 저장
     const [userName, setUserName] = useState(Cookies.get("userName") || null);
+    // 모바일 사이드바 열림 상태 관리
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
     // 유저 이름 가져오기
     useEffect(() => {
@@ -25,13 +27,29 @@ const AdminPageLayout = () => {
         navigate(previousPage);
     };
 
+    // 모바일 메뉴 토글
+    const toggleMobileMenu = () => {
+        setIsMobileMenuOpen(!isMobileMenuOpen);
+    };
+
+    // 모바일 메뉴 닫기
+    const closeMobileMenu = () => {
+        setIsMobileMenuOpen(false);
+    };
 
     return (
         <div className={styles.container}>
             {/* 헤더 */}
             <div className={styles.header}>
-
-                <span className={styles.logo} onClick={handleExit}>WAPs</span>
+                <div className={styles.headerLeft}>
+                    {/* 햄버거 아이콘 (CSS에서 1024px 이하일 때만 보임) */}
+                    <div className={styles.hamburger} onClick={toggleMobileMenu}>
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </div>
+                    <span className={styles.logo} onClick={handleExit}>WAPs</span>
+                </div>
 
                 <div className={styles.headerRight}>
                     <div className={styles.adminUser}>
@@ -43,8 +61,23 @@ const AdminPageLayout = () => {
 
             {/* 메인 */}
             <div className={styles.main}>
-                <SideBar />
-                <div className={styles.contentsBox} >
+                {/* 데스크탑용 사이드바 (CSS에서 화면 작아지면 숨김) */}
+                <div className={styles.sidebarWrapper}>
+                    <SideBar />
+                </div>
+
+                {/* 모바일용 사이드바 (상태값에 따라 렌더링) */}
+                {isMobileMenuOpen && (
+                    <>
+                        {/* 배경 클릭 시 닫기 위한 오버레이 */}
+                        <div className={styles.mobileSidebarOverlay} onClick={closeMobileMenu} />
+                        <div className={styles.mobileSidebarContent}>
+                            <SideBar />
+                        </div>
+                    </>
+                )}
+
+                <div className={styles.contentsBox}>
                     <Outlet />
                 </div>
             </div>

--- a/client/src/pages/adminPages/ManagePermissionPage.js
+++ b/client/src/pages/adminPages/ManagePermissionPage.js
@@ -195,7 +195,7 @@ const ManagePermissionPage = () => {
                 <div className={styles.changeContent}>
                     {/* 권한 선택 및 적용 버튼 UI */}
                     <div className={styles.controler}>
-                        <span style={{ fontSize: "18px", fontWeight: "700" }}>
+                        <span style={{ fontSize: "18px", fontWeight: "700", minWidth: "77px" }}>
                             다음으로 권한 변경:
                         </span>
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- #438 

## ✨ PR 세부 내용
투표 관리 기능은 거의 완성되었으나, 백엔드 쪽에서 작업이 먼저 되어야 완성이 될 기능이 남아 있어 이 작업 먼저 진행하였습니다!

1. 어드민 페이지의 `width` 값이 1024px 이하로 내려가면, 사이드바가 사라지면서 왼쪽 위에 메뉴 버튼이 생기도록 구현하였습니다.
2. 메뉴 버튼을 누르면 아래 사진과 같이 기존의 사이드바가 나오도록 하였습니다
<img width="987" height="875" alt="image" src="https://github.com/user-attachments/assets/07c5ad6f-7994-48e2-a0a6-bb6d07312346" /><img width="817" height="886" alt="image" src="https://github.com/user-attachments/assets/483b1300-80df-48ff-bfb8-2f6656810dd5" />


<!-- 수정/추가한 내용을 적어주세요. -->

## ⌛ 소요 시간