### PR TITLE
fix: 닫힌 투표여야만 투표 결과를 가져오도록 수정

### DIFF
--- a/server/src/main/java/wap/web2/server/vote/repository/BallotRepository.java
+++ b/server/src/main/java/wap/web2/server/vote/repository/BallotRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import wap.web2.server.admin.entity.VoteStatus;
 import wap.web2.server.vote.dto.ProjectVoteCount;
 import wap.web2.server.vote.entity.Ballot;
 
@@ -35,9 +36,10 @@ public interface BallotRepository extends JpaRepository<Ballot, Long> {
             WHERE b.semester = (
                 SELECT MAX(v.semester)
                 FROM VoteMeta v
-                WHERE v.semester <= :currentSemester and v.isResultPublic = true
+                WHERE v.semester <= :currentSemester and v.status = :ended and v.isResultPublic = true
             )
             GROUP BY b.projectId
             """)
-    List<ProjectVoteCount> findPublicLatestBallots(@Param("currentSemester") String currentSemester);
+    List<ProjectVoteCount> findPublicLatestBallots(@Param("currentSemester") String currentSemester,
+                                                   @Param("ended") VoteStatus ended);
 }

--- a/server/src/main/java/wap/web2/server/vote/service/VoteService.java
+++ b/server/src/main/java/wap/web2/server/vote/service/VoteService.java
@@ -85,7 +85,8 @@ public class VoteService {
     @Transactional(readOnly = true)
     public List<VoteResultResponse> getMostRecentResults() {
         String currentSemester = generateSemester();
-        List<ProjectVoteCount> latestVotes = ballotRepository.findPublicLatestBallots(currentSemester);
+        List<ProjectVoteCount> latestVotes = ballotRepository.findPublicLatestBallots(currentSemester,
+                VoteStatus.ENDED);
 
         if (latestVotes.isEmpty()) {
             throw new IllegalArgumentException("[ERROR] 현재까지 투표가 진행된 적이 없습니다.");


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->


## ✨ PR 세부 내용

투표가 닫혀야만 투표 결과를 가져올 수 있도록 수정합니다.

투표 결과 페이지에서 현재 진행중인 투표 결과가 실시간으로 보이지 않도록 수정하였습니다.

## ⌛ 소요 시간