### PR TITLE
fix: 권한 필터링 없을 때엔 모든 사용자 권한 목록을 가져오도록 수정

### DIFF
--- a/server/src/main/java/wap/web2/server/member/repository/UserRepository.java
+++ b/server/src/main/java/wap/web2/server/member/repository/UserRepository.java
@@ -24,7 +24,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
             """)
     int updateRoleByIds(@Param("role") Role role, @Param("ids") List<Long> ids);
 
-    @Query("SELECT u FROM User u WHERE u.role = :role ORDER BY u.id LIMIT :limit OFFSET :offset")
+    @Query("""
+            SELECT u
+            FROM User u
+            WHERE (:role IS NULL OR u.role = :role)
+            ORDER BY u.id
+            LIMIT :limit OFFSET :offset
+            """)
     List<User> findUserByOffset(@Param("limit") Integer limit,
                                 @Param("offset") Integer offset,
                                 @Param("role") Role role);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

## ✨ PR 세부 내용

사용자 권한 필터링을 적용하지 않았을 땐 모든 사용자 목록을 가져오도록 한다.

## ⌛ 소요 시간