### PR TITLE
fix: 사용자 권한 목록을 이름 기준으로 가져오고 코드에서 정렬하지 않도록 수정

### DIFF
--- a/server/src/main/java/wap/web2/server/admin/service/UserRoleService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/UserRoleService.java
@@ -1,6 +1,5 @@
 package wap.web2.server.admin.service;
 
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,15 +35,12 @@ public class UserRoleService {
     public UserRolePageResponse getUsersForAdmin(int size, int page, Role role) {
         int fetchSize = size + 1; // 다음 페이지 유무를 확인하기 위해 size보다 크게 가져옴
         int offset = page * size;
+
         List<User> users = userRepository.findUserByOffset(fetchSize, offset, role);
 
         boolean hasNext = false;
-        List<UserRoleResponse> content = users.stream()
-                .map(UserRoleResponse::from)
-                .sorted(Comparator
-                        .comparing(UserRoleResponse::role) // Role에 정의된 순서(ADMIN -> MEMBER -> USER -> GUEST)
-                        .thenComparing(UserRoleResponse::name))
-                .toList();
+        List<UserRoleResponse> content = users.stream().map(UserRoleResponse::from).toList();
+
         if (users.size() > size) {
             hasNext = true;
             content = content.subList(0, size);

--- a/server/src/main/java/wap/web2/server/member/repository/UserRepository.java
+++ b/server/src/main/java/wap/web2/server/member/repository/UserRepository.java
@@ -28,7 +28,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             SELECT u
             FROM User u
             WHERE (:role IS NULL OR u.role = :role)
-            ORDER BY u.id
+            ORDER BY u.name
             LIMIT :limit OFFSET :offset
             """)
     List<User> findUserByOffset(@Param("limit") Integer limit,


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Web] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->


## ✨ PR 세부 내용

사용자 권한 목록을 좀 더 사용하기 쉽도록 이름 기준으로 정렬합니다.

그리고 코드레벨에서 추가로 정렬하지 않도록 수정합니다.

## ⌛ 소요 시간