### PR TITLE
fix: 모바일에서 메뉴 창 하단이 잘리는 문제

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -69,12 +69,12 @@ ul {
 
 /* 본문 컨테이너 */
 .container {
-  background-color: #000; /* 페이지 배경 검정 */
+  background-color: #000;
   max-width: var(--container-max);
   margin-left: auto;
   margin-right: auto;
   border: 2px;
-  min-height: 100dvh;
+  min-height: calc(var(--vh, 1vh) * 100);
   box-sizing: border-box;
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { useEffect } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import ProjectPage from "./pages/ProjectPage";
 import Login from "./pages/Login";
@@ -29,6 +29,17 @@ import FullScreenLayout from "./components/FullScreenLayout";
 import "./App.css";
 
 function App() {
+  useEffect(() => {
+    const setScreenSize = () => {
+      let vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty("--vh", `${vh}px`);
+    };
+
+    setScreenSize();
+    window.addEventListener("resize", setScreenSize);
+
+    return () => window.removeEventListener("resize", setScreenSize);
+  }, []);
   return (
     <Router>
       <ScrollToTop /> {/* 페이지 전환 시 스크롤 위치 초기화 */}

--- a/client/src/assets/Menu.css
+++ b/client/src/assets/Menu.css
@@ -36,7 +36,7 @@ body:has(nav.menu) .App-header {
 
   width: 100%;
   max-width: var(--container-max, 400px); /* App.css 변수 사용, 없으면 400px */
-  height: 100dvh;
+  height: calc(var(--vh, 1vh) * 100);
 
   /* 배경 투명도 제거 및 기본 검정 배경 추가 */
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 10%, #000 42%),


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
간단한 문제라 따로 이슈를 열지는 않았습니다.

## ✨ PR 세부 내용
<!-- 수정/추가한 내용을 적어주세요. -->
모바일 환경에서 메뉴창에서만 하단이 잘리는 문제를 해결하였습니다.

1. `App.js`: useEffect를 사용하여 초기 렌더링 및 화면 리사이즈 시 window.innerHeight * 0.01을 계산, CSS 변수 --vh에 할당하는 로직을 추가하였습니다.
2. `App.css`: .container의 min-height를 100vh에서 calc(var(--vh, 1vh) * 100)로 변경하였습니다.
3. `menu.css`: menu의 height를 calc(var(--vh, 1vh) * 100)로 설정하여 모바일 툴바에 가려지는 영역 없이 스크롤 가능하도록 수정하였습니다.

## 👀 확인해주세요!
메뉴창 하단이 여전히 잘리는 문제가 발생하는지 확인 부탁드려요

## ⌛ 소요 시간
