### PR TITLE
feat: 탈취된 리프레시 토큰으로 Access Token을 갱신하려고 시도하면 사용자를 강제 로그아웃한다

### DIFF
--- a/server/src/main/java/wap/web2/server/auth/AuthService.java
+++ b/server/src/main/java/wap/web2/server/auth/AuthService.java
@@ -62,8 +62,7 @@ public class AuthService {
     }
 
     private Authentication createAuthentication(RefreshToken token) {
-        User user = userRepository.findById(token.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        User user = token.getUser();
         UserPrincipal userPrincipal = UserPrincipal.create(user);
         return new UsernamePasswordAuthenticationToken(userPrincipal, null, userPrincipal.getAuthorities());
     }

--- a/server/src/main/java/wap/web2/server/auth/RefreshTokenRepository.java
+++ b/server/src/main/java/wap/web2/server/auth/RefreshTokenRepository.java
@@ -11,7 +11,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     Optional<RefreshToken> findByToken(String token);
 
-    Optional<RefreshToken> findByUserId(Long userId);
+    Optional<RefreshToken> findByUser(User user);
 
     void deleteByUser(User user);
 }

--- a/server/src/main/java/wap/web2/server/auth/domain/RefreshToken.java
+++ b/server/src/main/java/wap/web2/server/auth/domain/RefreshToken.java
@@ -2,14 +2,18 @@ package wap.web2.server.auth.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import wap.web2.server.member.entity.User;
 
 @Getter
 @Setter
@@ -22,8 +26,9 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long userId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Column(nullable = false, unique = true)
     private String token;
@@ -31,8 +36,8 @@ public class RefreshToken {
     @Column(nullable = false)
     private Instant expiryDate;
 
-    private RefreshToken(Long userId, String token, Instant expiryDate) {
-        this.userId = userId;
+    private RefreshToken(User user, String token, Instant expiryDate) {
+        this.user = user;
         this.token = token;
         this.expiryDate = expiryDate;
     }
@@ -43,9 +48,9 @@ public class RefreshToken {
         return this;
     }
 
-    public static RefreshToken of(Long userId, String refreshToken, long refreshTokenExpiry) {
+    public static RefreshToken of(User user, String refreshToken, long refreshTokenExpiry) {
         Instant expiryDate = Instant.now().plusMillis(refreshTokenExpiry);
-        return new RefreshToken(userId, refreshToken, expiryDate);
+        return new RefreshToken(user, refreshToken, expiryDate);
     }
 
 }


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- #350

## ✨ PR 세부 내용
`/auth/refresh`를 통해 Access Token(이하 AT)을 갱신하려고 할 때 Refresh Token(이하 RT)이 탈취되었다고 판단되면 사용자를 강제로 로그아웃합니다.

토큰은 다음과 같은 경우에 탈취되었다고 판단합니다.
1. 잘못된 RT로 token refresh 시도
2. 존재하지 않는 RT로 token refresh 시도

이 둘은 모두 db에서 RT를 find하는 행위로 걸러낼 수 있습니다. 

공격자가 RT를 탈취하고 RT를 사용한다고 가정해봅시다.
1. 공격자는 RT를 통해 new AT를 발급받는다. (사용자의 정보를 뽑아내는 중..)
2. 사용자는 아무것도 모른채 RT로 AT를 재발급 받으려 한다. -> 이 때 서버는 DB에 저장된 RT와 다르므로 사용자를 강제로 로그아웃 시킨다.
3. 공격자가 탈취한 AT와 RT는 모두 무의미해졌다. 

이렇게 탈취된 토큰이 확인되면 사용자를 강제로 로그아웃 시켜 심각한 피해를 빠르게 방지합니다.

## 👀 확인해주세요!
물론 이 방법은 토큰이 탈취되었을 때 정보가 유출되는 것을 100%막을 수 없습니다. 단지 피해를 최소화하는 것일 뿐입니다.

## ⌛ 소요 시간
1h