### PR TITLE
fix: 배포 시 테스트 job 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,39 +10,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  test:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./server
-
-    steps:
-      - name: Checkout server only
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            server
-          sparse-checkout-cone-mode: true
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-          cache-dependency-path: server/build.gradle
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Run tests
-        run: ./gradlew test
-
   build:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
-    needs: test
 
     steps:
       - name: Checkout server only


### PR DESCRIPTION
##  📌 관련 이슈
- #issueNum

## ✨ PR 세부 내용
도커 이미지 생성 전 테스트를 수행하지 않도록 합니다.

이전 PR에서도 Actions가 실패하여 로그를 살펴보니 코드를 테스트 하는 job에서 문제가 생겼었습니다. VM에 mysql(DB) 이 존재하지 않는데 db관련 테스트가 수행되어 실패했습니다. 테스트는 코드를 배포하는 과정보다 통합할 때 수행되는게 좀 더 이상적인 구조 같아 제거하였습니다.
