### PR TITLE
fix: 어드민페이지 렌더링 충돌 문제 해결

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import ProjectPage from "./pages/ProjectPage";
 import Login from "./pages/Login";
 import ProjectDetailPage from "./pages/ProjectDetailPage";
@@ -76,6 +76,7 @@ function App() {
             element={<AdminRoute requireRole="ROLE_ADMIN" />}
           >
             <Route element={<AdminPageLayout />}>
+              <Route index element={<Navigate to="vote" replace />}></Route>
               <Route path="vote" element={<ManageVotePage />} />
               <Route path="teambuild" element={<ManageTeamBuildPage />} />
               <Route path="permission" element={<ManagePermissionPage />} />
@@ -85,7 +86,7 @@ function App() {
 
         </Route>
       </Routes>
-    </Router >
+    </Router>
   );
 }
 

--- a/client/src/pages/adminPages/ManageVotePage.js
+++ b/client/src/pages/adminPages/ManageVotePage.js
@@ -57,7 +57,7 @@ const ManageVotePage = () => {
                         semester: semester.split("-")[1]
                     }
                 });
-                setProjects(response.data.projectsResponse);
+                setProjects(response.data.projectsResponse || []);
             } catch (e) {
                 setError("프로젝트 목록 조회 실패");
             }
@@ -67,7 +67,7 @@ const ManageVotePage = () => {
 
     // 프젝목록을 모두 저장
     useEffect(() => {
-        if (projects.length > 0) {
+        if (projects && projects.length > 0) {
             setSelectedProjects(projects.map(p => p.projectId));
         }
     }, [projects]);


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- #542 

## ✨ PR 세부 내용
<!-- 수정/추가한 내용을 적어주세요. -->
1. `ManageVotePage.js`에서 프로젝트 리스트가 비어있는 경우 빈 리스트로 받아오도록 변경하였습니다. 또한, projects가 undefined일 경우, 여기서 .length를 참조하다가 발생할 수 있는 문제를 방지하였습니다.
2. 기존에 상위 경로로 사용하기 위해 만들었던 `/admin` 페이지에 접속할 경우 투표 관리 페이지로 리다이렉트 하도록 변경하였습니다.

## 👀 확인해주세요!


## ⌛ 소요 시간
~10M