### PR TITLE
refactor: 예외 핸들링 및 응답 표준화

### DIFF
--- a/server/src/main/java/wap/web2/server/admin/controller/AdminCalendarController.java
+++ b/server/src/main/java/wap/web2/server/admin/controller/AdminCalendarController.java
@@ -3,7 +3,6 @@ package wap.web2.server.admin.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 import wap.web2.server.admin.dto.request.CalendarEventPostingRequest;
 import wap.web2.server.admin.service.AdminCalendarService;
 
-@Slf4j
 @RestController
 @RequestMapping("/admin/calendar")
 @RequiredArgsConstructor
@@ -21,15 +19,9 @@ public class AdminCalendarController {
     private final AdminCalendarService adminCalendarService;
 
     @PostMapping("/event")
-    @Operation(summary = "일정 등록하기", description = "왑에서 진행될 일정을 등록합니다.")
-    public ResponseEntity<?> postCalendarEvent(@RequestBody @Valid CalendarEventPostingRequest request) {
-        try {
-            adminCalendarService.postCalendarEvent(request);
-            return ResponseEntity.ok().body("[INFO ] 성공적으로 일정을 등록하였습니다.");
-        } catch (Exception e) {
-            log.error("일정 등록시 에러 발생: {}", e.getMessage());
-            return ResponseEntity.badRequest().body("[ERROR] 등록 실패" + e.getMessage());
-        }
+    @Operation(summary = "일정 등록", description = "관리자 일정 이벤트를 등록합니다.")
+    public ResponseEntity<String> postCalendarEvent(@RequestBody @Valid CalendarEventPostingRequest request) {
+        adminCalendarService.postCalendarEvent(request);
+        return ResponseEntity.ok("일정이 등록되었습니다.");
     }
-
 }

--- a/server/src/main/java/wap/web2/server/admin/controller/AdminTeamBuildingController.java
+++ b/server/src/main/java/wap/web2/server/admin/controller/AdminTeamBuildingController.java
@@ -28,47 +28,37 @@ public class AdminTeamBuildingController {
     private final TeamBuildingExportService exportService;
     private final AdminTeamBuildingService adminTeamBuildingService;
 
-    // apply와 recruit이 준비되었을 때 팀 빌딩 알고리즘 실행 트리거
     @PostMapping("/building/run")
-    @Operation(summary = "팀 생성하기", description = "팀 지원과 팀원 모집이 완료되면 팀을 생성합니다.")
-    public ResponseEntity<?> makeTeam() {
-        try {
-            adminTeamBuildingService.makeTeam();
-            return ResponseEntity.ok().body("[INFO ] 성공적으로 분배하였습니다.");
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body("[ERROR] 분배 실패" + e.getMessage());
-        }
+    @Operation(summary = "팀 생성", description = "지원과 모집이 완료되면 팀을 생성합니다.")
+    public ResponseEntity<String> makeTeam() {
+        adminTeamBuildingService.makeTeam();
+        return ResponseEntity.ok("팀 분배가 완료되었습니다.");
     }
 
     @GetMapping("/building/status")
-    @Operation(summary = "팀빌딩 진행 상태 확인", description = "팀빌딩 기능의 상태를 반환합니다.")
-    public ResponseEntity<?> getStatus() {
-        try {
-            TeamBuildingStatus status = adminTeamBuildingService.getStatus();
-            return ResponseEntity.ok().body(TeamBuildingMetaStatusResponse.of(status));
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body("[ERROR] 확인 실패" + e.getMessage());
-        }
+    @Operation(summary = "팀빌딩 상태 조회", description = "현재 팀빌딩 기능의 상태를 조회합니다.")
+    public ResponseEntity<TeamBuildingMetaStatusResponse> getStatus() {
+        TeamBuildingStatus status = adminTeamBuildingService.getStatus();
+        return ResponseEntity.ok(TeamBuildingMetaStatusResponse.of(status));
     }
 
-    // TODO: status request를 역직렬화할 때 예외가 발생한다면
+    // TODO: status request를 직렬화했을 때 예외가 발생한다면?
     @PatchMapping("/building/status")
-    @Operation(summary = "팀빌딩 기능 상태 변경", description = "팀빌딩 기능의 상태를 열림, 지원중, 모집중, 닫힘 중 1가지로 변경합니다.")
-    public ResponseEntity<?> changeStatus(@RequestBody TeamBuildingStatusRequest statusRequest) {
+    @Operation(summary = "팀빌딩 상태 변경", description = "팀빌딩 상태를 변경합니다.")
+    public ResponseEntity<Void> changeStatus(@RequestBody TeamBuildingStatusRequest statusRequest) {
         adminTeamBuildingService.changeStatus(statusRequest);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/building/open/current")
-    @Operation(summary = "현재 학기의 팀빌딩 기능 생성", description = "현재 학기 팀빌딩 기능을 생성합니다.")
-    public ResponseEntity<?> openTeamBuilding() {
+    @Operation(summary = "현재 학기 팀빌딩 생성", description = "현재 학기의 팀빌딩 기능을 생성합니다.")
+    public ResponseEntity<Void> openTeamBuilding() {
         adminTeamBuildingService.openTeamBuilding(generateSemester());
         return ResponseEntity.ok().build();
     }
 
-    // 지원 현황 반환 (.CSV)
     @GetMapping(value = "/applies/export", produces = "text/csv; charset=UTF-8")
-    @Operation(summary = "지원 현황을 CSV로 내보내기", description = "현재까지 완성된 지원현황을 CSV 형식으로 내보냅니다.")
+    @Operation(summary = "지원 현황 CSV 다운로드", description = "현재까지의 지원 현황을 CSV 형식으로 다운로드합니다.")
     public ResponseEntity<byte[]> exportAppliesCsv() {
         byte[] bytes = exportService.generateAppliesCsvBytes();
 
@@ -80,9 +70,8 @@ public class AdminTeamBuildingController {
                 .body(bytes);
     }
 
-    // 모집 현황 반환 (.CSV)
     @GetMapping(value = "/recruits/export", produces = "text/csv; charset=UTF-8")
-    @Operation(summary = "모집 현황을 CSV로 내보내기", description = "현재까지 완성된 모집현황을 CSV 형식으로 내보냅니다.")
+    @Operation(summary = "모집 현황 CSV 다운로드", description = "현재까지의 모집 현황을 CSV 형식으로 다운로드합니다.")
     public ResponseEntity<byte[]> exportRecruitsCsv() {
         byte[] bytes = exportService.generateRecruitsCsvBytes();
 
@@ -93,5 +82,4 @@ public class AdminTeamBuildingController {
                 .contentLength(bytes.length)
                 .body(bytes);
     }
-
 }

--- a/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/AdminTeamBuildingService.java
@@ -21,6 +21,8 @@ import wap.web2.server.admin.dto.request.TeamBuildingStatusRequest;
 import wap.web2.server.admin.entity.TeamBuildingMeta;
 import wap.web2.server.admin.entity.TeamBuildingStatus;
 import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.ConflictException;
+import wap.web2.server.exception.ResourceNotFoundException;
 import wap.web2.server.project.entity.Project;
 import wap.web2.server.project.repository.ProjectRepository;
 import wap.web2.server.teambuild.dto.ApplyInfo;
@@ -59,14 +61,14 @@ public class AdminTeamBuildingService {
         TeamBuildingStatus status = statusRequest.status();
         int updated = teamBuildingMetaRepository.updateTeamBuildingMetaStatus(semester, status);
         if (updated == 0) {
-            throw new IllegalArgumentException(String.format("[ERROR] %s 학기의 팀빌딩이 존재하지 않습니다.", semester));
+            throw new ResourceNotFoundException(String.format("%s 학기의 팀빌딩을 찾을 수 없습니다.", semester));
         }
     }
 
     @Transactional
     public void openTeamBuilding(String semester) {
         if (teamBuildingMetaRepository.existsTeamBuildingMetaBySemester(semester)) {
-            throw new IllegalArgumentException("[ERROR] 해당 학기의 팀빌딩이 이미 생성되었습니다.");
+            throw new ConflictException("해당 학기의 팀빌딩이 이미 생성되었습니다.");
         }
 
         TeamBuildingMeta teamBuildingMeta = new TeamBuildingMeta(semester);
@@ -186,12 +188,12 @@ public class AdminTeamBuildingService {
     private TeamBuildingMeta findCurrentMeta() {
         String semester = generateSemester();
         return teamBuildingMetaRepository.findBySemester(semester)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 현재 학기의 팀빌딩이 초기화되지 않았습니다."));
+                .orElseThrow(() -> new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다."));
     }
 
     private void validateTeamBuildingStatus(TeamBuildingMeta current) {
         if (current.getStatus() != TeamBuildingStatus.CLOSED) {
-            throw new IllegalArgumentException("[ERROR] 팀빌딩 기능이 닫혀 있습니다");
+            throw new ConflictException("현재 팀빌딩 상태에서는 팀을 구성할 수 없습니다.");
         }
     }
 
@@ -202,7 +204,7 @@ public class AdminTeamBuildingService {
             Long projectId = projectEntry.getKey();
             Long leaderId = projectRepository.findById(projectId)
                     .map(project -> project.getUser().getId()) // leader id 찾기
-                    .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 프로젝트입니다."));
+                    .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
 
             Map<Position, Set<Long>> byPosition = projectEntry.getValue();
             for (Map.Entry<Position, Set<Long>> posEntry : byPosition.entrySet()) {

--- a/server/src/main/java/wap/web2/server/admin/service/AdminVoteService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/AdminVoteService.java
@@ -56,7 +56,7 @@ public class AdminVoteService {
     @Transactional
     public void closeVote(String semester, Long userId) {
         VoteMeta voteMeta = voteMetaRepository.findBySemester(semester)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 현재 학기의 투표가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResourceNotFoundException("해당 학기의 투표를 찾을 수 없습니다."));
 
         voteMeta.close(userId);
     }
@@ -78,7 +78,7 @@ public class AdminVoteService {
     @Transactional
     public VoteResultsVisibility getVisibility(String semester) {
         Boolean isPublic = voteMetaRepository.findIsResultPublicBySemester(semester)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 투표가 생성되지 않았습니다."));
+                .orElseThrow(() -> new ResourceNotFoundException("투표가 생성되지 않았습니다."));
         return new VoteResultsVisibility(isPublic);
     }
 
@@ -94,7 +94,7 @@ public class AdminVoteService {
         missing.removeAll(existingProjectIds);
 
         if (!missing.isEmpty()) {
-            throw new ResourceNotFoundException("[ERROR] 존재하지 않는 프로젝트가 포함되어 있습니다. missingIds=" + missing);
+            throw new ResourceNotFoundException("존재하지 않는 프로젝트가 포함되어 있습니다. missingIds=" + missing);
         }
     }
 

--- a/server/src/main/java/wap/web2/server/admin/service/TeamBuildingExportService.java
+++ b/server/src/main/java/wap/web2/server/admin/service/TeamBuildingExportService.java
@@ -12,6 +12,7 @@ import org.apache.commons.csv.CSVPrinter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import wap.web2.server.exception.InternalServerException;
 import wap.web2.server.teambuild.entity.ProjectApply;
 import wap.web2.server.teambuild.entity.ProjectRecruit;
 import wap.web2.server.teambuild.entity.ProjectRecruitWish;
@@ -58,7 +59,7 @@ public class TeamBuildingExportService {
             } while (!p.isLast());
 
         } catch (IOException e) {
-            throw new RuntimeException("[ERROR] applies CSV 생성 중 오류", e);
+            throw new InternalServerException("지원 CSV 생성 중 오류가 발생했습니다.", e);
         }
 
         return baos.toByteArray();
@@ -127,7 +128,7 @@ public class TeamBuildingExportService {
             } while (!p.isLast());
 
         } catch (IOException e) {
-            throw new RuntimeException("[ERROR] Recruits CSV 생성 중 오류", e);
+            throw new InternalServerException("모집 CSV 생성 중 오류가 발생했습니다.", e);
         }
 
         return baos.toByteArray();

--- a/server/src/main/java/wap/web2/server/auth/AuthController.java
+++ b/server/src/main/java/wap/web2/server/auth/AuthController.java
@@ -61,7 +61,6 @@ public class AuthController {
             throw new BadRequestException("Email address already in use.");
         }
 
-        // Creating user's account
         User user = new User();
         user.setName(signUpRequest.getName());
         user.setEmail(signUpRequest.getEmail());

--- a/server/src/main/java/wap/web2/server/auth/AuthController.java
+++ b/server/src/main/java/wap/web2/server/auth/AuthController.java
@@ -43,11 +43,13 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<AuthResponse> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         loginRequest.getEmail(),
-                        loginRequest.getPassword()));
+                        loginRequest.getPassword()
+                )
+        );
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
@@ -56,9 +58,9 @@ public class AuthController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<?> registerUser(@Valid @RequestBody SignUpRequest signUpRequest) {
+    public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody SignUpRequest signUpRequest) {
         if (userRepository.existsByEmail(signUpRequest.getEmail())) {
-            throw new BadRequestException("Email address already in use.");
+            throw new BadRequestException("이미 사용 중인 이메일입니다.");
         }
 
         User user = new User();
@@ -73,15 +75,17 @@ public class AuthController {
         User result = userRepository.save(user);
 
         URI location = ServletUriComponentsBuilder
-                .fromCurrentContextPath().path("/user/me")
-                .buildAndExpand(result.getId()).toUri();
+                .fromCurrentContextPath()
+                .path("/user/me")
+                .buildAndExpand(result.getId())
+                .toUri();
 
         return ResponseEntity.created(location)
-                .body(new ApiResponse(true, "User registered successfully@"));
+                .body(new ApiResponse(true, "회원가입이 완료되었습니다."));
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshToken(@CookieValue(name = "refresh_token") String refreshToken) {
+    public ResponseEntity<AuthResponse> refreshToken(@CookieValue(name = "refresh_token") String refreshToken) {
         Tokens newTokens = authService.createNewToken(refreshToken);
 
         long refreshTokenExpiry = appProperties.getAuth().getRefreshTokenExpirationMsec();
@@ -99,5 +103,4 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(new AuthResponse(newTokens.accessToken()));
     }
-
 }

--- a/server/src/main/java/wap/web2/server/auth/AuthService.java
+++ b/server/src/main/java/wap/web2/server/auth/AuthService.java
@@ -9,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import wap.web2.server.auth.domain.RefreshToken;
 import wap.web2.server.auth.domain.Tokens;
 import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.exception.ConflictException;
+import wap.web2.server.exception.ResourceNotFoundException;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.global.security.config.AppProperties;
 import wap.web2.server.global.security.jwt.TokenProvider;
@@ -27,14 +29,14 @@ public class AuthService {
     @Transactional
     public Tokens createNewToken(String token) {
         if (!tokenProvider.validateToken(token)) {
-            throw new BadRequestException("Invalid Refresh Token");
+            throw new BadRequestException("유효하지 않은 리프레시 토큰입니다.");
         }
 
         RefreshToken refreshToken = refreshTokenRepository.findByToken(token).orElse(null);
 
         if (refreshToken == null) {
             handleTokenTheft(token);
-            throw new BadRequestException("Refresh Token reuse detected");
+            throw new ConflictException("리프레시 토큰이 재사용되었습니다.");
         }
 
         validateToken(refreshToken);
@@ -50,7 +52,7 @@ public class AuthService {
     private void handleTokenTheft(String token) {
         Long userId = tokenProvider.getUserIdFromToken(token);
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BadRequestException("User not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
 
         refreshTokenRepository.deleteByUser(user);
     }
@@ -70,7 +72,7 @@ public class AuthService {
     private void validateToken(RefreshToken token) {
         if (token.getExpiryDate().isBefore(Instant.now())) {
             refreshTokenRepository.delete(token);
-            throw new BadRequestException("Refresh Token expired");
+            throw new BadRequestException("리프레시 토큰이 만료되었습니다.");
         }
     }
 }

--- a/server/src/main/java/wap/web2/server/auth/dto/LoginRequest.java
+++ b/server/src/main/java/wap/web2/server/auth/dto/LoginRequest.java
@@ -5,18 +5,14 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
-/**
- * Created by rajeevkumarsingh on 02/08/17.
- */
 @Getter
 @Setter
 public class LoginRequest {
 
-    @Email
-    @NotBlank
+    @Email(message = "올바른 이메일 형식을 입력해 주세요.")
+    @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
 
-    @NotBlank
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
     private String password;
-
 }

--- a/server/src/main/java/wap/web2/server/auth/dto/SignUpRequest.java
+++ b/server/src/main/java/wap/web2/server/auth/dto/SignUpRequest.java
@@ -5,22 +5,17 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
-/**
- * Created by rajeevkumarsingh on 02/08/17.
- */
-
 @Getter
 @Setter
 public class SignUpRequest {
 
-    @NotBlank
+    @NotBlank(message = "이름을 입력해 주세요.")
     private String name;
 
-    @Email
-    @NotBlank
+    @Email(message = "올바른 이메일 형식을 입력해 주세요.")
+    @NotBlank(message = "이메일을 입력해 주세요.")
     private String email;
 
-    @NotBlank
+    @NotBlank(message = "비밀번호를 입력해 주세요.")
     private String password;
-
 }

--- a/server/src/main/java/wap/web2/server/calendar/controller/CalendarController.java
+++ b/server/src/main/java/wap/web2/server/calendar/controller/CalendarController.java
@@ -2,7 +2,6 @@ package wap.web2.server.calendar.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,13 +17,8 @@ public class CalendarController {
     private final CalendarService calendarService;
 
     @GetMapping("/events")
-    public ResponseEntity<?> getActiveEvents() {
-        try {
-            List<CalendarEventResponse> activeEvents = calendarService.getActiveEvents();
-            return ResponseEntity.ok(activeEvents);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        }
+    public ResponseEntity<List<CalendarEventResponse>> getActiveEvents() {
+        List<CalendarEventResponse> activeEvents = calendarService.getActiveEvents();
+        return ResponseEntity.ok(activeEvents);
     }
-
 }

--- a/server/src/main/java/wap/web2/server/comment/controller/CommentController.java
+++ b/server/src/main/java/wap/web2/server/comment/controller/CommentController.java
@@ -1,7 +1,6 @@
 package wap.web2.server.comment.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,10 +8,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.comment.dto.request.CommentCreateRequest;
 import wap.web2.server.comment.service.CommentService;
 import wap.web2.server.global.security.CurrentUser;
+import wap.web2.server.global.security.UserPrincipal;
 
 @RestController
 @RequestMapping("/comment")
@@ -26,18 +25,14 @@ public class CommentController {
                                            @RequestBody CommentCreateRequest request,
                                            @CurrentUser UserPrincipal userPrincipal) {
         commentService.save(projectId, request, userPrincipal);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<String> deleteComment(@PathVariable("commentId") Long commentId,
                                                 @CurrentUser UserPrincipal userPrincipal) {
-        try {
-            commentService.delete(commentId, userPrincipal);
-            return ResponseEntity.ok("댓글이 삭제되었습니다.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
-        }
+        commentService.delete(commentId, userPrincipal);
+        return ResponseEntity.ok("댓글이 삭제되었습니다.");
     }
 
 }

--- a/server/src/main/java/wap/web2/server/comment/entity/Comment.java
+++ b/server/src/main/java/wap/web2/server/comment/entity/Comment.java
@@ -40,7 +40,10 @@ public class Comment {
     private User user;
 
     public boolean isOwner(User user) {
-        return this.user == user;
+        if (this.user == null || user == null) {
+            return false;
+        }
+        return this.user.getId().equals(user.getId());
     }
 
 }

--- a/server/src/main/java/wap/web2/server/comment/service/CommentService.java
+++ b/server/src/main/java/wap/web2/server/comment/service/CommentService.java
@@ -7,6 +7,8 @@ import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.comment.dto.request.CommentCreateRequest;
 import wap.web2.server.comment.entity.Comment;
 import wap.web2.server.comment.repository.CommentRepository;
+import wap.web2.server.exception.ForbiddenException;
+import wap.web2.server.exception.ResourceNotFoundException;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
 import wap.web2.server.project.entity.Project;
@@ -23,9 +25,9 @@ public class CommentService {
     @Transactional
     public void save(Long projectId, CommentCreateRequest request, UserPrincipal userPrincipal) {
         Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] Project not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
         User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] User not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
 
         commentRepository.save(request.toEntity(project, user));
     }
@@ -33,12 +35,12 @@ public class CommentService {
     @Transactional
     public void delete(Long commentId, UserPrincipal userPrincipal) {
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] Comment not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("댓글을 찾을 수 없습니다."));
         User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] User not found"));
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
 
         if (!comment.isOwner(user)) {
-            throw new IllegalArgumentException("[ERROR] Is not your comment");
+            throw new ForbiddenException("댓글 삭제 권한이 없습니다.");
         }
         commentRepository.delete(comment);
     }

--- a/server/src/main/java/wap/web2/server/exception/BadRequestException.java
+++ b/server/src/main/java/wap/web2/server/exception/BadRequestException.java
@@ -4,14 +4,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)
-public class BadRequestException extends RuntimeException {
+public class BadRequestException extends BusinessException {
 
     public BadRequestException(String message) {
-        super(message);
+        super(ErrorCode.COMMON_INVALID_INPUT, message);
     }
 
     public BadRequestException(String message, Throwable cause) {
-        super(message, cause);
+        super(ErrorCode.COMMON_INVALID_INPUT, message, cause);
     }
 
 }

--- a/server/src/main/java/wap/web2/server/exception/BusinessException.java
+++ b/server/src/main/java/wap/web2/server/exception/BusinessException.java
@@ -1,0 +1,37 @@
+package wap.web2.server.exception;
+
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다.").getDefaultMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다.");
+    }
+
+    public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다.");
+    }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(Objects.requireNonNull(errorCode, "errorCode는 null일 수 없습니다.").getDefaultMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/ConflictException.java
+++ b/server/src/main/java/wap/web2/server/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package wap.web2.server.exception;
+
+public class ConflictException extends BusinessException {
+
+    public ConflictException(String message) {
+        super(ErrorCode.COMMON_CONFLICT, message);
+    }
+
+    public ConflictException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/ErrorCode.java
+++ b/server/src/main/java/wap/web2/server/exception/ErrorCode.java
@@ -1,0 +1,41 @@
+package wap.web2.server.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    COMMON_INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "잘못된 요청입니다."),
+    COMMON_RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+    COMMON_CONFLICT(HttpStatus.CONFLICT, "COMMON_CONFLICT", "현재 요청을 처리할 수 없습니다."),
+    COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
+
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_UNAUTHORIZED", "인증이 필요합니다."),
+    AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_FORBIDDEN", "접근 권한이 없습니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_EXPIRED", "토큰이 만료되었습니다."),
+
+    TEAMBUILD_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "TEAMBUILD_ALREADY_SUBMITTED", "이미 제출된 모집이 존재합니다."),
+    PROJECT_PASSWORD_INVALID(HttpStatus.BAD_REQUEST, "PROJECT_PASSWORD_INVALID", "프로젝트 비밀번호가 올바르지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String defaultMessage;
+
+    ErrorCode(HttpStatus httpStatus, String code, String defaultMessage) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/ErrorCode.java
+++ b/server/src/main/java/wap/web2/server/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
     AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_UNAUTHORIZED", "인증이 필요합니다."),
     AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_FORBIDDEN", "접근 권한이 없습니다."),
+    AUTH_OAUTH2_FAILURE(HttpStatus.UNAUTHORIZED, "AUTH_OAUTH2_FAILURE", "소셜 로그인에 실패했습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_INVALID_TOKEN", "유효하지 않은 토큰입니다."),
     AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_EXPIRED", "토큰이 만료되었습니다."),
 

--- a/server/src/main/java/wap/web2/server/exception/ErrorResponse.java
+++ b/server/src/main/java/wap/web2/server/exception/ErrorResponse.java
@@ -1,0 +1,61 @@
+package wap.web2.server.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.Instant;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ErrorResponse(
+        Instant timestamp,
+        int status,
+        String code,
+        String message,
+        String path,
+        List<FieldErrorResponse> errors,
+        String requestId
+) {
+
+    public ErrorResponse {
+        timestamp = timestamp == null ? Instant.now() : timestamp;
+        errors = errors == null ? List.of() : List.copyOf(errors);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String path) {
+        return of(errorCode, errorCode.getDefaultMessage(), path);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message, String path) {
+        return of(errorCode, message, path, List.of(), null);
+    }
+
+    public static ErrorResponse of(
+            ErrorCode errorCode,
+            String message,
+            String path,
+            List<FieldErrorResponse> errors
+    ) {
+        return of(errorCode, message, path, errors, null);
+    }
+
+    public static ErrorResponse of(
+            ErrorCode errorCode,
+            String message,
+            String path,
+            List<FieldErrorResponse> errors,
+            String requestId
+    ) {
+        return new ErrorResponse(
+                Instant.now(),
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                hasText(message) ? message : errorCode.getDefaultMessage(),
+                path,
+                errors,
+                requestId
+        );
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/FieldErrorResponse.java
+++ b/server/src/main/java/wap/web2/server/exception/FieldErrorResponse.java
@@ -1,0 +1,8 @@
+package wap.web2.server.exception;
+
+public record FieldErrorResponse(
+        String field,
+        String message,
+        Object rejectedValue
+) {
+}

--- a/server/src/main/java/wap/web2/server/exception/ForbiddenException.java
+++ b/server/src/main/java/wap/web2/server/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package wap.web2.server.exception;
+
+public class ForbiddenException extends BusinessException {
+
+    public ForbiddenException(String message) {
+        super(ErrorCode.AUTH_FORBIDDEN, message);
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
@@ -1,0 +1,172 @@
+package wap.web2.server.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(
+            BusinessException exception,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = exception.getErrorCode();
+        ErrorResponse response = ErrorResponse.of(
+                errorCode,
+                exception.getMessage(),
+                request.getRequestURI(),
+                List.of(),
+                extractRequestId(request)
+        );
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception,
+            HttpServletRequest request
+    ) {
+        List<FieldErrorResponse> errors = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(this::toFieldErrorResponse)
+                .toList();
+
+        return badRequest("입력값을 확인해 주세요.", request, errors);
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBindException(
+            BindException exception,
+            HttpServletRequest request
+    ) {
+        List<FieldErrorResponse> errors = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(this::toFieldErrorResponse)
+                .toList();
+
+        return badRequest("요청 값을 확인해 주세요.", request, errors);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+            ConstraintViolationException exception,
+            HttpServletRequest request
+    ) {
+        List<FieldErrorResponse> errors = exception.getConstraintViolations()
+                .stream()
+                .map(this::toFieldErrorResponse)
+                .toList();
+
+        return badRequest("요청 값을 확인해 주세요.", request, errors);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException exception,
+            HttpServletRequest request
+    ) {
+        String message = String.format("필수 요청 파라미터 '%s'가 없습니다.", exception.getParameterName());
+        return badRequest(message, request, List.of());
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException exception,
+            HttpServletRequest request
+    ) {
+        String message = String.format("요청 파라미터 '%s'의 형식이 올바르지 않습니다.", exception.getName());
+        return badRequest(message, request, List.of());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException exception,
+            HttpServletRequest request
+    ) {
+        return badRequest("요청 본문을 올바르게 읽을 수 없습니다.", request, List.of());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        logger.error("처리되지 않은 예외가 발생했습니다. path={}", request.getRequestURI(), exception);
+
+        ErrorResponse response = ErrorResponse.of(
+                ErrorCode.COMMON_INTERNAL_SERVER_ERROR,
+                ErrorCode.COMMON_INTERNAL_SERVER_ERROR.getDefaultMessage(),
+                request.getRequestURI(),
+                List.of(),
+                extractRequestId(request)
+        );
+
+        return ResponseEntity.internalServerError().body(response);
+    }
+
+    private ResponseEntity<ErrorResponse> badRequest(
+            String message,
+            HttpServletRequest request,
+            List<FieldErrorResponse> errors
+    ) {
+        ErrorResponse response = ErrorResponse.of(
+                ErrorCode.COMMON_INVALID_INPUT,
+                message,
+                request.getRequestURI(),
+                errors,
+                extractRequestId(request)
+        );
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    private FieldErrorResponse toFieldErrorResponse(FieldError fieldError) {
+        return new FieldErrorResponse(
+                fieldError.getField(),
+                Objects.requireNonNullElse(fieldError.getDefaultMessage(), "입력값을 확인해 주세요."),
+                fieldError.getRejectedValue()
+        );
+    }
+
+    private FieldErrorResponse toFieldErrorResponse(ConstraintViolation<?> violation) {
+        return new FieldErrorResponse(
+                extractFieldName(violation),
+                violation.getMessage(),
+                violation.getInvalidValue()
+        );
+    }
+
+    private String extractFieldName(ConstraintViolation<?> violation) {
+        String propertyPath = violation.getPropertyPath().toString();
+        int lastDotIndex = propertyPath.lastIndexOf('.');
+        if (lastDotIndex >= 0 && lastDotIndex < propertyPath.length() - 1) {
+            return propertyPath.substring(lastDotIndex + 1);
+        }
+        return propertyPath;
+    }
+
+    private String extractRequestId(HttpServletRequest request) {
+        String requestId = request.getHeader("X-Request-Id");
+        return requestId == null || requestId.isBlank() ? null : requestId;
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
@@ -5,8 +5,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.List;
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.core.AuthenticationException;
@@ -19,10 +18,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(
@@ -138,7 +136,7 @@ public class GlobalExceptionHandler {
             Exception exception,
             HttpServletRequest request
     ) {
-        logger.error("처리되지 않은 예외가 발생했습니다. path={}", request.getRequestURI(), exception);
+        log.error("처리되지 않은 예외가 발생했습니다. path={}", request.getRequestURI(), exception);
 
         ErrorResponse response = ErrorResponse.of(
                 ErrorCode.COMMON_INTERNAL_SERVER_ERROR,

--- a/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
@@ -7,11 +7,13 @@ import java.util.List;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -37,6 +39,22 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(
+            AuthenticationException exception,
+            HttpServletRequest request
+    ) {
+        ErrorResponse response = ErrorResponse.of(
+                ErrorCode.AUTH_UNAUTHORIZED,
+                "이메일 또는 비밀번호를 확인해 주세요.",
+                request.getRequestURI(),
+                List.of(),
+                extractRequestId(request)
+        );
+
+        return ResponseEntity.status(ErrorCode.AUTH_UNAUTHORIZED.getHttpStatus()).body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -86,6 +104,15 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         String message = String.format("필수 요청 파라미터 '%s'가 없습니다.", exception.getParameterName());
+        return badRequest(message, request, List.of());
+    }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestCookieException(
+            MissingRequestCookieException exception,
+            HttpServletRequest request
+    ) {
+        String message = String.format("필수 쿠키 '%s'가 없습니다.", exception.getCookieName());
         return badRequest(message, request, List.of());
     }
 

--- a/server/src/main/java/wap/web2/server/exception/InternalServerException.java
+++ b/server/src/main/java/wap/web2/server/exception/InternalServerException.java
@@ -1,0 +1,12 @@
+package wap.web2.server.exception;
+
+public class InternalServerException extends BusinessException {
+
+    public InternalServerException(String message) {
+        super(ErrorCode.COMMON_INTERNAL_SERVER_ERROR, message);
+    }
+
+    public InternalServerException(String message, Throwable cause) {
+        super(ErrorCode.COMMON_INTERNAL_SERVER_ERROR, message, cause);
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/ProjectPasswordInvalidException.java
+++ b/server/src/main/java/wap/web2/server/exception/ProjectPasswordInvalidException.java
@@ -1,0 +1,12 @@
+package wap.web2.server.exception;
+
+public class ProjectPasswordInvalidException extends BusinessException {
+
+    public ProjectPasswordInvalidException() {
+        super(ErrorCode.PROJECT_PASSWORD_INVALID);
+    }
+
+    public ProjectPasswordInvalidException(String message) {
+        super(ErrorCode.PROJECT_PASSWORD_INVALID, message);
+    }
+}

--- a/server/src/main/java/wap/web2/server/exception/ResourceNotFoundException.java
+++ b/server/src/main/java/wap/web2/server/exception/ResourceNotFoundException.java
@@ -4,21 +4,27 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
-public class ResourceNotFoundException extends RuntimeException {
+public class ResourceNotFoundException extends BusinessException {
 
-    private String resourceName;
-    private String fieldName;
-    private Object fieldValue;
+    private final String resourceName;
+    private final String fieldName;
+    private final Object fieldValue;
 
     public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
-        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+        super(
+                ErrorCode.COMMON_RESOURCE_NOT_FOUND,
+                String.format("%s의 %s가 '%s'인 리소스를 찾을 수 없습니다.", resourceName, fieldName, fieldValue)
+        );
         this.resourceName = resourceName;
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
     }
 
     public ResourceNotFoundException(String message) {
-        super(message);
+        super(ErrorCode.COMMON_RESOURCE_NOT_FOUND, message);
+        this.resourceName = null;
+        this.fieldName = null;
+        this.fieldValue = null;
     }
 
     public String getResourceName() {

--- a/server/src/main/java/wap/web2/server/global/security/config/SecurityConfig.java
+++ b/server/src/main/java/wap/web2/server/global/security/config/SecurityConfig.java
@@ -24,8 +24,10 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import wap.web2.server.global.security.CustomUserDetailsService;
 import wap.web2.server.global.security.handler.OAuth2AuthenticationFailureHandler;
 import wap.web2.server.global.security.handler.OAuth2AuthenticationSuccessHandler;
+import wap.web2.server.global.security.handler.RestAccessDeniedHandler;
 import wap.web2.server.global.security.handler.RestAuthenticationEntryPoint;
 import wap.web2.server.global.security.jwt.TokenAuthenticationFilter;
+import wap.web2.server.global.security.jwt.TokenProvider;
 import wap.web2.server.global.security.oauth2.CustomOAuth2UserService;
 import wap.web2.server.global.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 
@@ -40,10 +42,13 @@ public class SecurityConfig {
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+    private final RestAccessDeniedHandler restAccessDeniedHandler;
+    private final TokenProvider tokenProvider;
 
     @Bean
     public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter();
+        return new TokenAuthenticationFilter(tokenProvider, customUserDetailsService);
     }
 
     @Bean
@@ -76,7 +81,9 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .exceptionHandling(exception -> exception.authenticationEntryPoint(new RestAuthenticationEntryPoint()))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(restAuthenticationEntryPoint)
+                        .accessDeniedHandler(restAccessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(staticResources()).permitAll()
 

--- a/server/src/main/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandler.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandler.java
@@ -8,8 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -18,12 +17,10 @@ import wap.web2.server.exception.ErrorCode;
 import wap.web2.server.global.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import wap.web2.server.util.CookieUtils;
 
-
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
-
-    private static final Logger logger = LoggerFactory.getLogger(OAuth2AuthenticationFailureHandler.class);
 
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
@@ -32,18 +29,18 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
                                         AuthenticationException exception) throws IOException, ServletException {
         String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
                 .map(Cookie::getValue)
-                .orElse(("/"));
+                .orElse("/");
 
-        logger.warn("OAuth2 로그인에 실패했습니다. path={}", request.getRequestURI(), exception);
+        log.warn("OAuth2 로그인에 실패했습니다. path={}", request.getRequestURI(), exception);
 
         targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("code", ErrorCode.AUTH_OAUTH2_FAILURE.getCode())
                 .queryParam("message", ErrorCode.AUTH_OAUTH2_FAILURE.getDefaultMessage())
-                .build().toUriString();
+                .build()
+                .toUriString();
 
         httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
-
 }

--- a/server/src/main/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandler.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/OAuth2AuthenticationFailureHandler.java
@@ -8,10 +8,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
+import wap.web2.server.exception.ErrorCode;
 import wap.web2.server.global.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import wap.web2.server.util.CookieUtils;
 
@@ -19,6 +22,8 @@ import wap.web2.server.util.CookieUtils;
 @Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(OAuth2AuthenticationFailureHandler.class);
 
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
@@ -29,8 +34,11 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
                 .map(Cookie::getValue)
                 .orElse(("/"));
 
+        logger.warn("OAuth2 로그인에 실패했습니다. path={}", request.getRequestURI(), exception);
+
         targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("error", exception.getLocalizedMessage())
+                .queryParam("code", ErrorCode.AUTH_OAUTH2_FAILURE.getCode())
+                .queryParam("message", ErrorCode.AUTH_OAUTH2_FAILURE.getDefaultMessage())
                 .build().toUriString();
 
         httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);

--- a/server/src/main/java/wap/web2/server/global/security/handler/RestAccessDeniedHandler.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/RestAccessDeniedHandler.java
@@ -5,18 +5,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import wap.web2.server.exception.ErrorCode;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class RestAccessDeniedHandler implements AccessDeniedHandler {
-
-    private static final Logger logger = LoggerFactory.getLogger(RestAccessDeniedHandler.class);
 
     private final SecurityErrorResponseWriter securityErrorResponseWriter;
 
@@ -26,7 +24,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException, ServletException {
-        logger.warn("인가에 실패했습니다. path={}", request.getRequestURI(), accessDeniedException);
+        log.warn("인가에 실패했습니다. path={}", request.getRequestURI(), accessDeniedException);
         securityErrorResponseWriter.write(
                 request,
                 response,

--- a/server/src/main/java/wap/web2/server/global/security/handler/RestAccessDeniedHandler.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/RestAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package wap.web2.server.global.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import wap.web2.server.exception.ErrorCode;
+
+@Component
+@RequiredArgsConstructor
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestAccessDeniedHandler.class);
+
+    private final SecurityErrorResponseWriter securityErrorResponseWriter;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        logger.warn("인가에 실패했습니다. path={}", request.getRequestURI(), accessDeniedException);
+        securityErrorResponseWriter.write(
+                request,
+                response,
+                ErrorCode.AUTH_FORBIDDEN,
+                ErrorCode.AUTH_FORBIDDEN.getDefaultMessage()
+        );
+    }
+}

--- a/server/src/main/java/wap/web2/server/global/security/handler/RestAuthenticationEntryPoint.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/RestAuthenticationEntryPoint.java
@@ -4,22 +4,46 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import wap.web2.server.exception.ErrorCode;
 
+@Component
+@RequiredArgsConstructor
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private static final Logger logger = LoggerFactory.getLogger(RestAuthenticationEntryPoint.class);
+    private final SecurityErrorResponseWriter securityErrorResponseWriter;
 
     @Override
     public void commence(HttpServletRequest httpServletRequest,
                          HttpServletResponse httpServletResponse,
                          AuthenticationException e) throws IOException, ServletException {
-        logger.error("Responding with unauthorized error. Message - {}", e.getMessage());
-        httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED,
-                e.getLocalizedMessage());
+        ErrorCode errorCode = resolveErrorCode(httpServletRequest);
+        String message = resolveMessage(httpServletRequest, errorCode);
+
+        logger.warn("인증에 실패했습니다. path={}, code={}", httpServletRequest.getRequestURI(), errorCode.getCode(), e);
+        securityErrorResponseWriter.write(httpServletRequest, httpServletResponse, errorCode, message);
+    }
+
+    private ErrorCode resolveErrorCode(HttpServletRequest request) {
+        Object errorCode = request.getAttribute(SecurityErrorResponseWriter.ERROR_CODE_REQUEST_ATTRIBUTE);
+        if (errorCode instanceof ErrorCode value) {
+            return value;
+        }
+        return ErrorCode.AUTH_UNAUTHORIZED;
+    }
+
+    private String resolveMessage(HttpServletRequest request, ErrorCode errorCode) {
+        Object message = request.getAttribute(SecurityErrorResponseWriter.ERROR_MESSAGE_REQUEST_ATTRIBUTE);
+        if (message instanceof String value && !value.isBlank()) {
+            return value;
+        }
+        return errorCode.getDefaultMessage();
     }
 
 }

--- a/server/src/main/java/wap/web2/server/global/security/handler/RestAuthenticationEntryPoint.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/RestAuthenticationEntryPoint.java
@@ -5,18 +5,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import wap.web2.server.exception.ErrorCode;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private static final Logger logger = LoggerFactory.getLogger(RestAuthenticationEntryPoint.class);
     private final SecurityErrorResponseWriter securityErrorResponseWriter;
 
     @Override
@@ -26,7 +25,7 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
         ErrorCode errorCode = resolveErrorCode(httpServletRequest);
         String message = resolveMessage(httpServletRequest, errorCode);
 
-        logger.warn("인증에 실패했습니다. path={}, code={}", httpServletRequest.getRequestURI(), errorCode.getCode(), e);
+        log.warn("인증에 실패했습니다. path={}, code={}", httpServletRequest.getRequestURI(), errorCode.getCode(), e);
         securityErrorResponseWriter.write(httpServletRequest, httpServletResponse, errorCode, message);
     }
 
@@ -45,5 +44,4 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
         }
         return errorCode.getDefaultMessage();
     }
-
 }

--- a/server/src/main/java/wap/web2/server/global/security/handler/SecurityErrorResponseWriter.java
+++ b/server/src/main/java/wap/web2/server/global/security/handler/SecurityErrorResponseWriter.java
@@ -1,0 +1,49 @@
+package wap.web2.server.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import wap.web2.server.exception.ErrorCode;
+import wap.web2.server.exception.ErrorResponse;
+import wap.web2.server.exception.FieldErrorResponse;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityErrorResponseWriter {
+
+    public static final String ERROR_CODE_REQUEST_ATTRIBUTE = "security.errorCode";
+    public static final String ERROR_MESSAGE_REQUEST_ATTRIBUTE = "security.errorMessage";
+
+    private final ObjectMapper objectMapper;
+
+    public void write(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            ErrorCode errorCode,
+            String message
+    ) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.of(
+                errorCode,
+                message,
+                request.getRequestURI(),
+                List.<FieldErrorResponse>of(),
+                extractRequestId(request)
+        );
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+
+    private String extractRequestId(HttpServletRequest request) {
+        String requestId = request.getHeader("X-Request-Id");
+        return requestId == null || requestId.isBlank() ? null : requestId;
+    }
+}

--- a/server/src/main/java/wap/web2/server/global/security/jwt/TokenAuthenticationFilter.java
+++ b/server/src/main/java/wap/web2/server/global/security/jwt/TokenAuthenticationFilter.java
@@ -6,8 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,10 +17,9 @@ import wap.web2.server.exception.ErrorCode;
 import wap.web2.server.global.security.CustomUserDetailsService;
 import wap.web2.server.global.security.handler.SecurityErrorResponseWriter;
 
+@Slf4j
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
-
-    private static final Logger logger = LoggerFactory.getLogger(TokenAuthenticationFilter.class);
 
     private final TokenProvider tokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
@@ -34,7 +32,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(jwt)) {
             ErrorCode tokenErrorCode = tokenProvider.getAccessTokenErrorCode(jwt);
             if (tokenErrorCode != null) {
-                logger.warn("JWT 인증에 실패했습니다. path={}, code={}", request.getRequestURI(), tokenErrorCode.getCode());
+                log.warn("JWT 인증에 실패했습니다. path={}, code={}", request.getRequestURI(), tokenErrorCode.getCode());
                 request.setAttribute(SecurityErrorResponseWriter.ERROR_CODE_REQUEST_ATTRIBUTE, tokenErrorCode);
                 request.setAttribute(SecurityErrorResponseWriter.ERROR_MESSAGE_REQUEST_ATTRIBUTE, tokenErrorCode.getDefaultMessage());
                 SecurityContextHolder.clearContext();
@@ -48,7 +46,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } catch (Exception exception) {
-                    logger.error("JWT 인증 처리 중 오류가 발생했습니다. path={}", request.getRequestURI(), exception);
+                    log.error("JWT 인증 처리 중 오류가 발생했습니다. path={}", request.getRequestURI(), exception);
                     request.setAttribute(SecurityErrorResponseWriter.ERROR_CODE_REQUEST_ATTRIBUTE, ErrorCode.AUTH_UNAUTHORIZED);
                     request.setAttribute(
                             SecurityErrorResponseWriter.ERROR_MESSAGE_REQUEST_ATTRIBUTE,
@@ -65,9 +63,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7, bearerToken.length());
+            return bearerToken.substring(7);
         }
         return null;
     }
-
 }

--- a/server/src/main/java/wap/web2/server/global/security/jwt/TokenAuthenticationFilter.java
+++ b/server/src/main/java/wap/web2/server/global/security/jwt/TokenAuthenticationFilter.java
@@ -5,44 +5,58 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import wap.web2.server.exception.ErrorCode;
 import wap.web2.server.global.security.CustomUserDetailsService;
+import wap.web2.server.global.security.handler.SecurityErrorResponseWriter;
 
+@RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(TokenAuthenticationFilter.class);
 
-    @Autowired
-    private TokenProvider tokenProvider;
-    @Autowired
-    private CustomUserDetailsService customUserDetailsService;
+    private final TokenProvider tokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        try {
-            String jwt = getJwtFromRequest(request);
+        String jwt = getJwtFromRequest(request);
 
-            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-                Long userId = tokenProvider.getUserIdFromToken(jwt);
+        if (StringUtils.hasText(jwt)) {
+            ErrorCode tokenErrorCode = tokenProvider.getAccessTokenErrorCode(jwt);
+            if (tokenErrorCode != null) {
+                logger.warn("JWT 인증에 실패했습니다. path={}, code={}", request.getRequestURI(), tokenErrorCode.getCode());
+                request.setAttribute(SecurityErrorResponseWriter.ERROR_CODE_REQUEST_ATTRIBUTE, tokenErrorCode);
+                request.setAttribute(SecurityErrorResponseWriter.ERROR_MESSAGE_REQUEST_ATTRIBUTE, tokenErrorCode.getDefaultMessage());
+                SecurityContextHolder.clearContext();
+            } else {
+                try {
+                    Long userId = tokenProvider.getUserIdFromToken(jwt);
+                    UserDetails userDetails = customUserDetailsService.loadUserById(userId);
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-                UserDetails userDetails = customUserDetailsService.loadUserById(userId);
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities());
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (Exception exception) {
+                    logger.error("JWT 인증 처리 중 오류가 발생했습니다. path={}", request.getRequestURI(), exception);
+                    request.setAttribute(SecurityErrorResponseWriter.ERROR_CODE_REQUEST_ATTRIBUTE, ErrorCode.AUTH_UNAUTHORIZED);
+                    request.setAttribute(
+                            SecurityErrorResponseWriter.ERROR_MESSAGE_REQUEST_ATTRIBUTE,
+                            ErrorCode.AUTH_UNAUTHORIZED.getDefaultMessage()
+                    );
+                    SecurityContextHolder.clearContext();
+                }
             }
-        } catch (Exception ex) {
-            logger.error("Could not set user authentication in security context", ex);
         }
 
         filterChain.doFilter(request, response);

--- a/server/src/main/java/wap/web2/server/global/security/jwt/TokenProvider.java
+++ b/server/src/main/java/wap/web2/server/global/security/jwt/TokenProvider.java
@@ -10,25 +10,22 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import wap.web2.server.exception.ErrorCode;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.global.security.config.AppProperties;
 
+@Slf4j
 @Service
 public class TokenProvider {
-
-    private static final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
 
     private final AppProperties appProperties;
     private final Key key;
 
     public TokenProvider(AppProperties appProperties) {
         this.appProperties = appProperties;
-        // 문자열로부터 HMAC SHA 키 생성 (64바이트 이상 권장)
         this.key = Keys.hmacShaKeyFor(appProperties.getAuth().getTokenSecret().getBytes(StandardCharsets.UTF_8));
     }
 
@@ -79,18 +76,17 @@ public class TokenProvider {
             Jwts.parser().setSigningKey(key).build().parseClaimsJws(authToken);
             return null;
         } catch (SecurityException | MalformedJwtException ex) {
-            logger.warn("유효하지 않은 JWT 서명입니다. message={}", ex.getMessage());
+            log.warn("유효하지 않은 JWT 서명입니다. message={}", ex.getMessage());
             return ErrorCode.AUTH_INVALID_TOKEN;
         } catch (ExpiredJwtException ex) {
-            logger.warn("만료된 JWT 토큰입니다. message={}", ex.getMessage());
+            log.warn("만료된 JWT 토큰입니다. message={}", ex.getMessage());
             return ErrorCode.AUTH_TOKEN_EXPIRED;
         } catch (UnsupportedJwtException ex) {
-            logger.warn("지원하지 않는 JWT 토큰입니다. message={}", ex.getMessage());
+            log.warn("지원하지 않는 JWT 토큰입니다. message={}", ex.getMessage());
             return ErrorCode.AUTH_INVALID_TOKEN;
         } catch (IllegalArgumentException ex) {
-            logger.warn("JWT 토큰이 비어 있습니다. message={}", ex.getMessage());
+            log.warn("JWT 토큰이 비어 있습니다. message={}", ex.getMessage());
             return ErrorCode.AUTH_INVALID_TOKEN;
         }
     }
-
 }

--- a/server/src/main/java/wap/web2/server/global/security/jwt/TokenProvider.java
+++ b/server/src/main/java/wap/web2/server/global/security/jwt/TokenProvider.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import wap.web2.server.exception.ErrorCode;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.global.security.config.AppProperties;
 
@@ -70,19 +71,26 @@ public class TokenProvider {
     }
 
     public boolean validateToken(String authToken) {
+        return getAccessTokenErrorCode(authToken) == null;
+    }
+
+    public ErrorCode getAccessTokenErrorCode(String authToken) {
         try {
             Jwts.parser().setSigningKey(key).build().parseClaimsJws(authToken);
-            return true;
+            return null;
         } catch (SecurityException | MalformedJwtException ex) {
-            logger.error("Invalid JWT signature: {}", ex.getMessage());
+            logger.warn("유효하지 않은 JWT 서명입니다. message={}", ex.getMessage());
+            return ErrorCode.AUTH_INVALID_TOKEN;
         } catch (ExpiredJwtException ex) {
-            logger.error("Expired JWT token: {}", ex.getMessage());
+            logger.warn("만료된 JWT 토큰입니다. message={}", ex.getMessage());
+            return ErrorCode.AUTH_TOKEN_EXPIRED;
         } catch (UnsupportedJwtException ex) {
-            logger.error("Unsupported JWT token: {}", ex.getMessage());
+            logger.warn("지원하지 않는 JWT 토큰입니다. message={}", ex.getMessage());
+            return ErrorCode.AUTH_INVALID_TOKEN;
         } catch (IllegalArgumentException ex) {
-            logger.error("JWT token is empty: {}", ex.getMessage());
+            logger.warn("JWT 토큰이 비어 있습니다. message={}", ex.getMessage());
+            return ErrorCode.AUTH_INVALID_TOKEN;
         }
-        return false;
     }
 
 }

--- a/server/src/main/java/wap/web2/server/member/controller/UserController.java
+++ b/server/src/main/java/wap/web2/server/member/controller/UserController.java
@@ -2,15 +2,14 @@ package wap.web2.server.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.global.security.CurrentUser;
+import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.dto.UserResponse;
 import wap.web2.server.member.dto.UserRoleResponse;
 import wap.web2.server.member.dto.UserVoteResponse;
@@ -24,34 +23,28 @@ public class UserController {
 
     private final UserService userService;
 
-    // 자신의 회원 정보를 리턴
-    @GetMapping("/me") // @CurrentUser : 프론트에서 주는 토큰을 가지고 객체를 만들어줌
+    @GetMapping("/me")
     public ResponseEntity<?> findUserDetail(@CurrentUser UserPrincipal userPrincipal) {
         UserResponse response = userService.getUserDetail(userPrincipal);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/vote/{semester}")
     public ResponseEntity<?> getMyVotedInfo(@CurrentUser UserPrincipal userPrincipal,
                                             @PathVariable("semester") @Semester String semester) {
         UserVoteResponse response = userService.getUserVotedInfo(userPrincipal, semester);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return ResponseEntity.ok(response);
     }
 
-    // 회원 구분 선택
     @PostMapping("/role/{role}")
     public ResponseEntity<?> setMyRole(@CurrentUser UserPrincipal userPrincipal,
                                        @PathVariable("role") String role) {
-        try {
-            userService.setRole(userPrincipal, role);
-            return ResponseEntity.ok("회원 등록에 성공했습니다!");
-        } catch (Exception e) {
-            return ResponseEntity.status(401).body("회원 등록에 실패했습니다!");
-        }
+        userService.setRole(userPrincipal, role);
+        return ResponseEntity.ok("회원 등록에 성공했습니다!");
     }
 
     @GetMapping("/role")
-    @Operation(summary = "사용자 권한 확인", description = "사용자가 권한을 설정했는지, 어떤 권한을 가지는지 확인합니다.")
+    @Operation(summary = "사용자 권한 확인", description = "사용자가 권한을 설정했는지, 어떤 권한을 가지고 있는지 확인합니다.")
     public ResponseEntity<?> getMyRole(@CurrentUser UserPrincipal userPrincipal) {
         UserRoleResponse response = userService.getMyRole(userPrincipal.getId());
         return ResponseEntity.ok(response);

--- a/server/src/main/java/wap/web2/server/member/entity/Role.java
+++ b/server/src/main/java/wap/web2/server/member/entity/Role.java
@@ -1,6 +1,7 @@
 package wap.web2.server.member.entity;
 
 import java.util.Arrays;
+import wap.web2.server.exception.BadRequestException;
 
 public enum Role {
 
@@ -13,7 +14,7 @@ public enum Role {
         return Arrays.stream(Role.values())
                 .filter(role -> role.name().equalsIgnoreCase(value))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 유효하지 않은 역할입니다: " + value));
+                .orElseThrow(() -> new BadRequestException("유효하지 않은 역할입니다: " + value));
     }
 
 }

--- a/server/src/main/java/wap/web2/server/member/service/UserService.java
+++ b/server/src/main/java/wap/web2/server/member/service/UserService.java
@@ -3,8 +3,8 @@ package wap.web2.server.member.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.exception.ResourceNotFoundException;
+import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.dto.UserResponse;
 import wap.web2.server.member.dto.UserRoleResponse;
 import wap.web2.server.member.dto.UserVoteResponse;
@@ -20,38 +20,32 @@ public class UserService {
     private final BallotRepository ballotRepository;
     private final UserRepository userRepository;
 
-    // 유저 정보 조회
     public UserResponse getUserDetail(UserPrincipal userPrincipal) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getId()));
-
+        User user = findUser(userPrincipal.getId());
         return UserResponse.of(user);
     }
 
-    // 유저가 투표한 프로젝트 id 3개 반환
     public UserVoteResponse getUserVotedInfo(UserPrincipal userPrincipal, String semester) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-
+        User user = findUser(userPrincipal.getId());
         List<Long> projectIds = ballotRepository.findProjectIdsByUserIdAndSemester(user.getId(), semester);
         return new UserVoteResponse(projectIds);
     }
 
     public void setRole(UserPrincipal userPrincipal, String role) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-
+        User user = findUser(userPrincipal.getId());
         user.setRole(Role.from(role));
         userRepository.save(user);
     }
 
     public UserRoleResponse getMyRole(Long id) {
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
+        User user = findUser(id);
         Role role = user.getRole();
-        boolean isAssigned = (role != null);
-
+        boolean isAssigned = role != null;
         return new UserRoleResponse(role, isAssigned);
     }
-}
 
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/server/src/main/java/wap/web2/server/project/controller/ProjectController.java
+++ b/server/src/main/java/wap/web2/server/project/controller/ProjectController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Encoding;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.env.PropertyResolver;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +18,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import wap.web2.server.global.security.UserPrincipal;
+import wap.web2.server.exception.BadRequestException;
 import wap.web2.server.global.security.CurrentUser;
+import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.project.dto.request.ProjectRequest;
 import wap.web2.server.project.dto.response.ProjectDetailsResponse;
 import wap.web2.server.project.dto.response.ProjectInfoResponse;
@@ -35,9 +35,8 @@ public class ProjectController {
 
     private final ProjectService projectService;
     private final ApplyService applyService;
-    private final PropertyResolver propertyResolver;
 
-    // TODO: ProjectsResponse에 담기 전에 검사하는건 별로인가요?
+    // TODO: ProjectsResponse를 만들기 전에 검사하거나 별도로 할까?
     //  또는 컨트롤러에서는 try catch를 두고 ProjectResponse안에서 throw 하는 것은?
     @GetMapping("/list")
     public ResponseEntity<?> getProjects(@RequestParam("projectYear") Integer year,
@@ -48,13 +47,13 @@ public class ProjectController {
                 .build();
 
         if (projectsResponse.getProjectsResponse().isEmpty()) {
-            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            return ResponseEntity.noContent().build();
         }
-        return new ResponseEntity<>(projectsResponse, HttpStatus.OK);
+        return ResponseEntity.ok(projectsResponse);
     }
 
-    // TODO: 투표가 먼저 생성되고 있음
-    // TODO: 입력 폼 변경해야함
+    // TODO: 파일과 객체가 같이 생성되고 있음
+    // TODO: 입력 값 변경해야함
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(
             encoding = @Encoding(name = "project", contentType = MediaType.APPLICATION_JSON_VALUE)
@@ -63,7 +62,7 @@ public class ProjectController {
                                            @RequestPart(value = "image", required = false) List<MultipartFile> imageFiles,
                                            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnailFile,
                                            @RequestPart("project") ProjectRequest request) throws IOException {
-        // RequestPart 중 ContentType 형식이 다르게 온 file 2종류를 ProjectCreateRequest 에 할당하여 새로운 RequestDto 객체 생성
+        // RequestPart 중 ContentType 형식이 서로 다른 file 2종류를 ProjectCreateRequest 에 할당하여 새로운 RequestDto 객체 생성
         ProjectRequest fullRequest = ProjectRequest.builder()
                 .title(request.getTitle())
                 .projectType(request.getProjectType())
@@ -75,47 +74,31 @@ public class ProjectController {
                 .teamMember(request.getTeamMember())
                 .techStack(request.getTechStack())
                 .image(request.getImage())
-                .imageS3(imageFiles) // image file 초기화
+                .imageS3(imageFiles)
                 .thumbnail(request.getThumbnail())
-                .thumbnailS3(thumbnailFile) // thumbnail file 초기화
+                .thumbnailS3(thumbnailFile)
                 .build();
 
         // 비밀번호가 null 인지 체크
-        if (fullRequest.getPassword() == null) {
-            return ResponseEntity.status(400).body("비밀번호를 입력하세요.");
-        }
+        validatePassword(fullRequest.getPassword());
 
         String result = projectService.save(fullRequest, userPrincipal);
-
-        if (result.equals("비밀번호가 틀렸습니다.")) {
-            return ResponseEntity.status(401).body(result);
-        } else {
-            return ResponseEntity.status(201).body(result);
-        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
     @GetMapping("/{projectId}")
     public ResponseEntity<?> getProject(@PathVariable("projectId") Long projectId,
                                         @CurrentUser UserPrincipal userPrincipal) {
-        try {
-            ProjectDetailsResponse projectDetails = projectService.getProjectDetails(projectId, userPrincipal);
-            return ResponseEntity.ok(projectDetails);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        }
+        ProjectDetailsResponse projectDetails = projectService.getProjectDetails(projectId, userPrincipal);
+        return ResponseEntity.ok(projectDetails);
     }
 
     @GetMapping("/{projectId}/update")
     public ResponseEntity<?> getProjectDetailsForUpdate(@PathVariable("projectId") Long projectId,
                                                         @CurrentUser UserPrincipal userPrincipal) {
-        try {
-            // 프로젝트 상세 정보를 가져오는 서비스 호출
-            ProjectDetailsResponse response = projectService.getProjectDetailsForUpdate(projectId, userPrincipal);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        } catch (IllegalArgumentException ex) {
-            // 유효하지 않은 유저 ID
-            return ResponseEntity.status(403).body("수정 권한이 없습니다.");
-        }
+        // 프로젝트 상세 정보를 가져오는 서비스 호출
+        ProjectDetailsResponse response = projectService.getProjectDetailsForUpdate(projectId, userPrincipal);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping("{projectId}")
@@ -124,32 +107,26 @@ public class ProjectController {
                                            @RequestPart(value = "image", required = false) List<MultipartFile> imageFiles,
                                            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnailFile,
                                            @RequestPart("project") ProjectRequest request) throws IOException {
-        // RequestPart 중 ContentType 형식이 다르게 온 file 2종류를 ProjectRequest 에 할당
+        // RequestPart 중 ContentType 형식이 서로 다른 file 2종류를 ProjectRequest 에 할당
         request.setMultipartFiles(thumbnailFile, imageFiles);
 
         // 비밀번호가 null 인지 체크
-        if (request.getPassword() == null) {
-            return ResponseEntity.status(400).body("비밀번호를 입력하세요.");
-        }
+        validatePassword(request.getPassword());
 
         String result = projectService.update(projectId, request, userPrincipal);
-        if (result.equals("비밀번호가 틀렸습니다.")) {
-            return ResponseEntity.status(401).body(result);
-        } else {
-            return ResponseEntity.status(201).body(result);
-        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
     @DeleteMapping("{projectId}")
-    public ResponseEntity<?> deleteProject(@PathVariable("projectId") Long projectId, @CurrentUser UserPrincipal user) {
-        try {
-            projectService.delete(projectId, user);
-            return ResponseEntity.noContent().build();
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An unexpected error occurred.");
-        }
+    public ResponseEntity<?> deleteProject(@PathVariable("projectId") Long projectId,
+                                           @CurrentUser UserPrincipal user) {
+        projectService.delete(projectId, user);
+        return ResponseEntity.noContent().build();
     }
 
+    private void validatePassword(String password) {
+        if (password == null) {
+            throw new BadRequestException("비밀번호를 입력하세요.");
+        }
+    }
 }

--- a/server/src/main/java/wap/web2/server/project/dto/response/TechStackInfoResponse.java
+++ b/server/src/main/java/wap/web2/server/project/dto/response/TechStackInfoResponse.java
@@ -3,6 +3,7 @@ package wap.web2.server.project.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import wap.web2.server.exception.BadRequestException;
 import wap.web2.server.project.entity.TechStackName;
 import wap.web2.server.project.entity.TechStackType;
 
@@ -54,7 +55,7 @@ public class TechStackInfoResponse {
             case TENSERFLOW:
                 return TechStackType.AI;
             default:
-                throw new IllegalArgumentException("Unknown TechStackName: " + techStackName);
+                throw new BadRequestException("알 수 없는 기술 스택입니다: " + techStackName);
         }
     }
 }

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.aws.AwsUtils;
+import wap.web2.server.exception.ForbiddenException;
+import wap.web2.server.exception.ProjectPasswordInvalidException;
 import wap.web2.server.exception.ResourceNotFoundException;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
@@ -49,11 +51,10 @@ public class ProjectService {
     @Transactional
     public String save(ProjectRequest request, UserPrincipal userPrincipal) throws IOException {
         if (request.getPassword() == null || !request.getPassword().equals(projectPassword)) {
-            return "비밀번호가 틀렸습니다.";
+            throw new ProjectPasswordInvalidException();
         }
 
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
+        User user = findUser(userPrincipal.getId());
 
         List<String> imageUrls = Collections.emptyList();
         if (request.getImageS3() != null) {
@@ -108,8 +109,7 @@ public class ProjectService {
         ProjectDetailsResponse projectDetailsResponse = ProjectDetailsResponse.from(project);
 
         if (userPrincipal != null) {
-            User user = userRepository.findById(userPrincipal.getId())
-                    .orElseThrow(() -> new IllegalArgumentException("Invalid user Id")); // 아래 메서드와 예외처리를 동일하게
+            User user = findUser(userPrincipal.getId());
 
             if (project.isOwner(user)) {
                 // 로그인한 사용자이고, 프로젝트의 주인이면 isOwner 플래그를 true로 바꾸고 리턴한다.
@@ -123,17 +123,16 @@ public class ProjectService {
     @CacheEvict(value = "projectList", allEntries = true)
     public ProjectDetailsResponse getProjectDetailsForUpdate(Long projectId, UserPrincipal userPrincipal) {
         if (userPrincipal == null) {
-            throw new IllegalArgumentException();
+            throw new ForbiddenException("프로젝트 수정 권한이 없습니다.");
         }
 
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("Invalid user Id"));
+        User user = findUser(userPrincipal.getId());
         log.info("[수정 요청] - 유저ID: {}, 유저명: {}, 프로젝트ID: {}", user.getId(), user.getName(), projectId);
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("프로젝트가 없습니다."));
 
         if (!project.getUser().getId().equals(user.getId())) {
-            throw new IllegalArgumentException("수정 권한이 없습니다.");
+            throw new ForbiddenException("프로젝트 수정 권한이 없습니다.");
         }
 
         return ProjectDetailsResponse.from(project);
@@ -143,13 +142,16 @@ public class ProjectService {
     @Transactional
     public String update(Long projectId, ProjectRequest request, UserPrincipal userPrincipal) throws IOException {
         if (request.getPassword() == null || !request.getPassword().equals(projectPassword)) {
-            return "비밀번호가 틀렸습니다.";
+            throw new ProjectPasswordInvalidException();
         }
 
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-        Project project = projectRepository.findByProjectIdAndUser(projectId, user.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 프로젝트의 생성자가 아닙니다."));
+        User user = findUser(userPrincipal.getId());
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
+
+        if (!project.isOwner(user)) {
+            throw new ForbiddenException("프로젝트 수정 권한이 없습니다.");
+        }
 
         // 썸네일 이미지가 없으면 유지 or 있으면 변경
         if (request.getThumbnailS3() != null) {
@@ -186,25 +188,28 @@ public class ProjectService {
     @CacheEvict(value = "projectList", allEntries = true)
     @Transactional
     public void delete(Long projectId, UserPrincipal userPrincipal) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-        Project project = projectRepository.findByProjectIdAndUser(projectId, user.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 프로젝트의 생성자가 아닙니다."));
+        User user = findUser(userPrincipal.getId());
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
 
-        if (project == null) {
-            throw new IllegalArgumentException("[ERROR] 해당 사용자에게 삭제 권한이 없습니다.");
+        if (!project.isOwner(user)) {
+            throw new ForbiddenException("프로젝트 삭제 권한이 없습니다.");
         }
         projectRepository.delete(project);
     }
 
     public boolean isLeader(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
+        User user = findUser(userId);
 
         // 이번 학기 모든 프로젝트를 찾아서 내가 주인인 프로젝트가 하나라도 있으면 true
         return projectRepository.findProjectsByYearAndSemester(generateYearValue(), generateSemesterValue())
                 .stream()
                 .anyMatch(project -> project.isOwner(user));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
     }
 
 }

--- a/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
+++ b/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
@@ -56,20 +56,20 @@ public class TeamBuildingControllerV3 {
     public ResponseEntity<String> apply(@CurrentUser UserPrincipal userPrincipal,
                                         @Valid @RequestBody ProjectAppliesRequest request) {
         applyService.apply(userPrincipal, request);
-        return ResponseEntity.ok("[INFO ] 성공적으로 지원하였습니다.");
+        return ResponseEntity.ok("지원이 완료되었습니다.");
     }
 
     @PostMapping("/recruit/submit")
     public ResponseEntity<String> setPreference(@CurrentUser UserPrincipal userPrincipal,
                                                 @Valid @RequestBody RecruitmentDto request) {
         applyService.setPreference(userPrincipal, request);
-        return ResponseEntity.ok("[INFO ] 성공적으로 등록하였습니다.");
+        return ResponseEntity.ok("모집 정보가 등록되었습니다.");
     }
 
     @GetMapping("/{projectId}/applies")
     public ResponseEntity<ProjectAppliesResponse> getRecruitPageData(@CurrentUser UserPrincipal userPrincipal,
                                                                      @PathVariable("projectId") Long projectId) {
-        ProjectAppliesResponse response = applyService.getApplies(userPrincipal, projectId);
+        ProjectAppliesResponse response = applyService.getRecruitPageData(userPrincipal, projectId);
         return ResponseEntity.ok(response);
     }
 

--- a/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
+++ b/server/src/main/java/wap/web2/server/teambuild/controller/TeamBuildingControllerV3.java
@@ -3,7 +3,6 @@ package wap.web2.server.teambuild.controller;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,100 +34,51 @@ public class TeamBuildingControllerV3 {
     private final ProjectService projectService;
     private final ApplyService applyService;
 
-    // 팀 빌딩 시 사용되는 "내 역할(팀장 or 팀원)" 반환
     @GetMapping("/role")
-    public ResponseEntity<?> getMyRole(@CurrentUser UserPrincipal userPrincipal) {
-        try {
-            boolean isLeader = projectService.isLeader(userPrincipal.getId());
-            return ResponseEntity.ok(new RoleResponse(isLeader ? "leader" : "member"));
-        } catch (Exception e) {
-            return ResponseEntity.status(401).body("[ERROR] 잘못된 유저입니다.");
-        }
+    public ResponseEntity<RoleResponse> getMyRole(@CurrentUser UserPrincipal userPrincipal) {
+        boolean isLeader = projectService.isLeader(userPrincipal.getId());
+        return ResponseEntity.ok(new RoleResponse(isLeader ? "leader" : "member"));
     }
 
-    // 팀원 지원 상태(이미 지원 완료 여부) 확인
     @GetMapping("/apply/status")
-    public ResponseEntity<?> getApplyStatus(@CurrentUser UserPrincipal userPrincipal) {
-        try {
-            boolean hasApplied = applyService.hasAppliedThisSemester(userPrincipal.getId());
-            return ResponseEntity.ok(new ApplyStatusResponse(hasApplied));
-        } catch (Exception e) {
-            return ResponseEntity.status(401).body("[ERROR] 잘못된 유저입니다.");
-        }
+    public ResponseEntity<ApplyStatusResponse> getApplyStatus(@CurrentUser UserPrincipal userPrincipal) {
+        boolean hasApplied = applyService.hasAppliedThisSemester(userPrincipal.getId());
+        return ResponseEntity.ok(new ApplyStatusResponse(hasApplied));
     }
 
-    // 팀빌딩 지원 가능한 프로젝트 목록
     @GetMapping("/projects")
-    public ResponseEntity<?> getCurrentProjects(@CurrentUser UserPrincipal userPrincipal) {
-        try {
-            List<ProjectTemplate> projects = projectService.getCurrentProjectRecruits();
-            return ResponseEntity.ok(projects);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("[ERROR] 프로젝트 목록을 불러오지 못했습니다.");
-        }
+    public ResponseEntity<List<ProjectTemplate>> getCurrentProjects(@CurrentUser UserPrincipal userPrincipal) {
+        List<ProjectTemplate> projects = projectService.getCurrentProjectRecruits();
+        return ResponseEntity.ok(projects);
     }
 
-    // 프로젝트 신청 (for 팀원)
     @PostMapping("/apply/submit")
-    public ResponseEntity<?> apply(@CurrentUser UserPrincipal userPrincipal,
-                                   @Valid @RequestBody ProjectAppliesRequest request) {
-//        try {
+    public ResponseEntity<String> apply(@CurrentUser UserPrincipal userPrincipal,
+                                        @Valid @RequestBody ProjectAppliesRequest request) {
         applyService.apply(userPrincipal, request);
-        return ResponseEntity.ok().body("[INFO ] 성공적으로 지원하였습니다.");
-//        } catch (Exception e) {
-//            return ResponseEntity.badRequest().body("[ERROR] 지원 실패");
-//        }
+        return ResponseEntity.ok("[INFO ] 성공적으로 지원하였습니다.");
     }
 
-    // 희망 팀 구성 제출 (for 팀장)
     @PostMapping("/recruit/submit")
-    public ResponseEntity<?> setPreference(@CurrentUser UserPrincipal userPrincipal,
-                                           @Valid @RequestBody RecruitmentDto request) {
-        try {
-            applyService.setPreference(userPrincipal, request);
-            return ResponseEntity.ok().body("[INFO ] 성공적으로 등록하였습니다.");
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body("[ERROR] 등록 실패");
-        }
+    public ResponseEntity<String> setPreference(@CurrentUser UserPrincipal userPrincipal,
+                                                @Valid @RequestBody RecruitmentDto request) {
+        applyService.setPreference(userPrincipal, request);
+        return ResponseEntity.ok("[INFO ] 성공적으로 등록하였습니다.");
     }
 
-    // 내 프로젝트에 지원한 멤버 불러오기
     @GetMapping("/{projectId}/applies")
-    public ResponseEntity<?> getRecruitPageData(@CurrentUser UserPrincipal userPrincipal,
-                                                @PathVariable("projectId") Long projectId) {
-        try {
-            // 이미 모집 제출된 상태인지 검사
-            boolean hasApplied = applyService.hasRecruited(userPrincipal, projectId);
-            if (hasApplied) {
-                return ResponseEntity.status(HttpStatus.CONFLICT).body("[ERROR] 이미 제출된 모집이 존재합니다.");
-            }
-
-            // 프로젝트 지원자 목록 조회
-            ProjectAppliesResponse response = applyService.getApplies(userPrincipal, projectId);
-
-            return ResponseEntity.ok(response);
-
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("[ERROR] 멤버 불러오기가 실패했습니다. " + e.getMessage());
-        }
+    public ResponseEntity<ProjectAppliesResponse> getRecruitPageData(@CurrentUser UserPrincipal userPrincipal,
+                                                                     @PathVariable("projectId") Long projectId) {
+        ProjectAppliesResponse response = applyService.getApplies(userPrincipal, projectId);
+        return ResponseEntity.ok(response);
     }
 
-    // 팀 빌딩 결과를 가져오기
     @GetMapping("/results")
-    public ResponseEntity<?> getTeamBuildResults() {
-        try {
-            TeamBuildingResults results = teamBuildingResultService.getResults();
-            List<TeamMemberResult> unassigned = teamBuildingResultService.getUnassignedMembers(results);
+    public ResponseEntity<TeamResultsResponse> getTeamBuildResults() {
+        TeamBuildingResults results = teamBuildingResultService.getResults();
+        List<TeamMemberResult> unassigned = teamBuildingResultService.getUnassignedMembers(results);
 
-            // response가 requests: { requests : {}, unassigned: {} } 즉, requests가 requests를 감싸는 구조를 해결.
-            //  TeamBuildingResults의 일급컬랙션 형태를 유지하기위해서 results에서 results를 꺼냄.
-            TeamResultsResponse response = new TeamResultsResponse(results.getResults(), unassigned);
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body("[ERROR] 결과 불러오기 실패" + e.getMessage());
-        }
+        TeamResultsResponse response = new TeamResultsResponse(results.getResults(), unassigned);
+        return ResponseEntity.ok(response);
     }
-
 }

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -11,6 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 import wap.web2.server.admin.entity.TeamBuildingMeta;
 import wap.web2.server.admin.entity.TeamBuildingStatus;
 import wap.web2.server.admin.repository.TeamBuildingMetaRepository;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.exception.ConflictException;
+import wap.web2.server.exception.ForbiddenException;
+import wap.web2.server.exception.ResourceNotFoundException;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.User;
 import wap.web2.server.member.repository.UserRepository;
@@ -44,24 +48,21 @@ public class ApplyService {
     @Transactional
     public void apply(UserPrincipal userPrincipal, ProjectAppliesRequest request) {
         if (!isTeamApplyOpen()) {
-            throw new IllegalArgumentException("[ERROR] 팀빌딩 지원 기능이 열리지 않았습니다.");
+            throw new ConflictException("현재 팀빌딩 상태에서는 지원할 수 없습니다.");
         }
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
 
-        // TODO: 이미 신청한 사용자 처리
-
+        User user = findUser(userPrincipal.getId());
         List<ApplyRequest> applies = request.getApplies();
-        int priority = 1; // 우선순위는 1-based
+        int priority = 1;
+
         for (ApplyRequest applyRequest : applies) {
-            Project project = projectRepository.findById(applyRequest.getProjectId())
-                    .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 프로젝트입니다."));
+            Project project = findProject(applyRequest.getProjectId());
             log.info("apply-user:{},priority:{},project:{}", userPrincipal.getName(), priority, project.getTitle());
 
             applyRepository.save(
                     ProjectApply.builder()
                             .priority(priority++)
-                            .position(Position.valueOf(applyRequest.getPosition()))
+                            .position(parsePosition(applyRequest.getPosition()))
                             .comment(applyRequest.getComment())
                             .user(user)
                             .project(project)
@@ -70,16 +71,13 @@ public class ApplyService {
         }
     }
 
-    // 이미 모집했는가
     @Transactional(readOnly = true)
     public boolean hasRecruited(UserPrincipal userPrincipal, Long projectId) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 프로젝트입니다."));
+        User user = findUser(userPrincipal.getId());
+        Project project = findProject(projectId);
 
         if (!project.isOwner(user)) {
-            throw new IllegalArgumentException("[ERROR] 프로젝트의 팀장이 아닙니다.");
+            throw new ForbiddenException("프로젝트 열람 권한이 없습니다.");
         }
 
         return recruitRepository.existsByProjectIdAndSemester(projectId, generateSemester());
@@ -87,13 +85,11 @@ public class ApplyService {
 
     @Transactional(readOnly = true)
     public ProjectAppliesResponse getApplies(UserPrincipal userPrincipal, Long projectId) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 프로젝트입니다."));
+        User user = findUser(userPrincipal.getId());
+        Project project = findProject(projectId);
 
         if (!project.isOwner(user)) {
-            throw new IllegalArgumentException("[ERROR] 해당 프로젝트의 팀장이 아닙니다.");
+            throw new ForbiddenException("프로젝트 열람 권한이 없습니다.");
         }
 
         List<ProjectApply> applies = applyRepository.findAllByProject(project);
@@ -102,33 +98,41 @@ public class ApplyService {
         return ProjectAppliesResponse.fromEntities(applies);
     }
 
-    // 팀장이 선호하는 지원자를 나열한 wishList 저장
+    @Transactional(readOnly = true)
+    public ProjectAppliesResponse getRecruitPageData(UserPrincipal userPrincipal, Long projectId) {
+        if (hasRecruited(userPrincipal, projectId)) {
+            throw new ConflictException("이미 제출된 모집이 존재합니다.");
+        }
+
+        return getApplies(userPrincipal, projectId);
+    }
+
     @Transactional
     public void setPreference(UserPrincipal userPrincipal, RecruitmentDto request) {
         if (!isTeamRecruitOpen()) {
-            throw new IllegalArgumentException("[ERROR] 팀빌딩 모집 기능이 열리지 않았습니다.");
+            throw new ConflictException("현재 팀빌딩 상태에서는 모집을 제출할 수 없습니다.");
         }
 
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-        Project project = projectRepository.findById(request.getProjectId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 프로젝트입니다."));
+        User user = findUser(userPrincipal.getId());
+        Project project = findProject(request.getProjectId());
 
-        log.info("setPreference요청-user:{},project:{}", user.getId(), project.getProjectId());
+        if (!project.isOwner(user)) {
+            throw new ForbiddenException("프로젝트 모집 권한이 없습니다.");
+        }
+
+        log.info("setPreference-user:{},project:{}", user.getId(), project.getProjectId());
 
         List<RecruitmentInfo> roasters = request.getRoasters();
         for (RecruitmentInfo roaster : roasters) {
-            // 1. 먼저 ProjectRecruit 저장 (부모 엔티티)
             ProjectRecruit recruit = recruitRepository.save(
                     ProjectRecruit.builder()
                             .leaderId(user.getId())
                             .projectId(project.getProjectId())
-                            .position(Position.valueOf(roaster.getPosition()))
+                            .position(parsePosition(roaster.getPosition()))
                             .capacity(roaster.getCapacity())
                             .build()
             );
 
-            // 2. 각 분야별로 우선순위 1부터 시작
             int priority = 1;
             List<ProjectRecruitWish> wishes = new ArrayList<>();
             for (long applicantId : roaster.getApplicantIds()) {
@@ -142,19 +146,20 @@ public class ApplyService {
                 wishes.add(wish);
             }
 
-            // 3. 부모 엔티티에 자식 리스트 설정
             recruit.setWishList(wishes);
         }
     }
 
+    @Transactional(readOnly = true)
     public boolean hasAppliedThisSemester(Long userId) {
+        findUser(userId);
         return applyRepository.existsByUserIdAndSemester(userId, generateSemester());
     }
 
     private boolean isTeamApplyOpen() {
         String semester = generateSemester();
         TeamBuildingMeta teamBuildingMeta = teamBuildingMetaRepository.findBySemester(semester)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 현재 학기의 팀빌딩이 초기화되지 않았습니다."));
+                .orElseThrow(() -> new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다."));
 
         return teamBuildingMeta.getStatus() == TeamBuildingStatus.APPLY;
     }
@@ -162,8 +167,26 @@ public class ApplyService {
     private boolean isTeamRecruitOpen() {
         String semester = generateSemester();
         TeamBuildingMeta teamBuildingMeta = teamBuildingMetaRepository.findBySemester(semester)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 현재 학기의 팀빌딩이 초기화되지 않았습니다."));
+                .orElseThrow(() -> new ConflictException("현재 학기의 팀빌딩이 초기화되지 않았습니다."));
 
         return teamBuildingMeta.getStatus() == TeamBuildingStatus.RECRUIT;
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+
+    private Project findProject(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
+    }
+
+    private Position parsePosition(String position) {
+        try {
+            return Position.valueOf(position);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("유효하지 않은 포지션입니다.");
+        }
     }
 }

--- a/server/src/main/java/wap/web2/server/vote/controller/VoteController.java
+++ b/server/src/main/java/wap/web2/server/vote/controller/VoteController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,8 +11,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.global.security.CurrentUser;
+import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.util.Semester;
 import wap.web2.server.util.SemesterGenerator;
 import wap.web2.server.vote.dto.VoteInfoResponse;
@@ -30,55 +29,40 @@ public class VoteController {
     private final VoteService voteService;
 
     @PostMapping
-    public ResponseEntity<?> voteProjects(@CurrentUser UserPrincipal userPrincipal,
-                                          @RequestBody @Valid VoteRequest voteRequest) {
-        try {
-            String role = userPrincipal.getUserRole()
-                    .orElseThrow(() -> new IllegalArgumentException("[ERROR] 사용자의 권한 정보가 존재하지 않습니다."));
-
-            voteService.vote(userPrincipal.getId(), role, voteRequest);
-            return new ResponseEntity<>(HttpStatus.OK);
-        } catch (IllegalStateException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
-        }
+    public ResponseEntity<Void> voteProjects(@CurrentUser UserPrincipal userPrincipal,
+                                             @RequestBody @Valid VoteRequest voteRequest) {
+        voteService.vote(userPrincipal, voteRequest);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{semester}/projects")
-    @Operation(summary = "투표에 참여하는 프로젝트 리스트", description = "특정 학기 투표에 참여하는 프로젝트 리스트를 가져옵니다.")
-    public ResponseEntity<?> getVoteParticipants(@PathVariable("semester") @Semester String semester) {
+    @Operation(summary = "투표 참여 프로젝트 목록 조회", description = "특정 학기 투표에 참여하는 프로젝트 목록을 조회합니다.")
+    public ResponseEntity<List<VoteParticipantsResponse>> getVoteParticipants(
+            @PathVariable("semester") @Semester String semester
+    ) {
         List<VoteParticipantsResponse> participants = voteService.getParticipants(semester);
         return ResponseEntity.ok(participants);
     }
 
     @GetMapping("/now")
-    @Operation(summary = "현재 학기 투표 상태 보기", description = "현재 학기에 '열린 투표'인지, '내가 투표했는지', '닫힌 투표인지'를 반환한다")
-    public ResponseEntity<?> getVoteInfo(@CurrentUser UserPrincipal userPrincipal) {
-        try {
-            // 해당 api는 "현재 학기"로 고정이다.
-            String semester = SemesterGenerator.generateSemester();
-            VoteInfoResponse response = voteService.getVoteInfo(userPrincipal, semester);
-            return ResponseEntity.ok().body(response);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    @Operation(summary = "현재 학기 투표 상태 조회", description = "현재 학기 투표 여부와 투표 진행 상태를 조회합니다.")
+    public ResponseEntity<VoteInfoResponse> getVoteInfo(@CurrentUser UserPrincipal userPrincipal) {
+        String semester = SemesterGenerator.generateSemester();
+        VoteInfoResponse response = voteService.getVoteInfo(userPrincipal, semester);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/result")
-    @Operation(summary = "최신 투표 결과 확인", description = "가장 최신의 투표 결과를 반환한다. 현재 학기 투표 결과가 없다면 이전 학기 중 가장 가까운 학기의 결과를 가져온다.")
-    public ResponseEntity<?> getMostRecentResults() {
+    @Operation(summary = "최신 투표 결과 조회", description = "가장 최신 공개 투표 결과를 조회합니다.")
+    public ResponseEntity<VoteResultsResponse> getMostRecentResults() {
         VoteResultsResponse voteResults = voteService.getMostRecentResults();
-        return ResponseEntity.ok().body(voteResults);
+        return ResponseEntity.ok(voteResults);
     }
 
     @GetMapping("/result/{semester}")
-    @Operation(summary = "특정 학기 투표 결과 확인", description = "특정 학기의 투표 결과를 가져온다.")
-    public ResponseEntity<?> getVoteResults(@PathVariable("semester") @Semester String semester) {
+    @Operation(summary = "학기별 투표 결과 조회", description = "특정 학기의 투표 결과를 조회합니다.")
+    public ResponseEntity<VoteResultsResponse> getVoteResults(@PathVariable("semester") @Semester String semester) {
         VoteResultsResponse voteResults = voteService.getVoteResults(semester);
-        return ResponseEntity.ok().body(voteResults);
+        return ResponseEntity.ok(voteResults);
     }
-
 }

--- a/server/src/main/java/wap/web2/server/vote/service/VoteService.java
+++ b/server/src/main/java/wap/web2/server/vote/service/VoteService.java
@@ -12,6 +12,10 @@ import org.springframework.transaction.annotation.Transactional;
 import wap.web2.server.admin.entity.VoteMeta;
 import wap.web2.server.admin.entity.VoteStatus;
 import wap.web2.server.admin.repository.VoteMetaRepository;
+import wap.web2.server.exception.BadRequestException;
+import wap.web2.server.exception.ConflictException;
+import wap.web2.server.exception.ForbiddenException;
+import wap.web2.server.exception.ResourceNotFoundException;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.Role;
 import wap.web2.server.member.entity.User;
@@ -35,20 +39,20 @@ public class VoteService {
     private final VoteMetaRepository voteMetaRepository;
 
     @Transactional
-    public void vote(Long userId, String role, VoteRequest voteRequest) {
+    public void vote(UserPrincipal userPrincipal, VoteRequest voteRequest) {
+        Long userId = userPrincipal.getId();
+        Role userRole = resolveUserRole(userPrincipal);
         String semester = voteRequest.semester();
-        Role userRole = Role.from(role);
 
-        VoteMeta voteMeta = voteMetaRepository.findBySemester(semester)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 투표가 존재하지 않습니다."));
-
+        VoteMeta voteMeta = findVoteMeta(semester);
         if (voteMeta.getStatus() != VoteStatus.VOTING) {
-            throw new IllegalArgumentException(String.format("[ERROR] %s학기의 투표가 열리지 않았습니다.", semester));
+            throw new ConflictException(String.format("%s 학기의 투표가 진행 중이 아닙니다.", semester));
         }
 
         List<Long> projectIds = voteRequest.projectIds();
         validateUserBallot(semester, userId);
         validateParticipatingProjects(projectIds, voteMeta.getId());
+
         for (Long projectId : projectIds) {
             ballotRepository.save(Ballot.of(semester, userId, userRole, projectId));
         }
@@ -56,14 +60,12 @@ public class VoteService {
 
     @Transactional(readOnly = true)
     public VoteInfoResponse getVoteInfo(UserPrincipal userPrincipal, String semester) {
-        User user = userRepository.findById(userPrincipal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
-        VoteStatus voteStatus = voteMetaRepository.findStatusBySemester(semester)
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 투표가 존재하지 않습니다."));
+        User user = findUser(userPrincipal.getId());
+        VoteStatus voteStatus = findVoteStatus(semester);
 
         long votedCount = ballotRepository.countBallotsBySemesterAndUserId(semester, user.getId());
         boolean isVotedUser = votedCount > 0;
-        boolean isOpen = (voteStatus == VoteStatus.VOTING);
+        boolean isOpen = voteStatus == VoteStatus.VOTING;
 
         return VoteInfoResponse.builder()
                 .isVotedUser(isVotedUser)
@@ -80,7 +82,7 @@ public class VoteService {
         long totalVotes = calculateTotalVotes(projectVoteCounts);
 
         List<VoteResultResponse> results = projectVoteCounts.stream()
-                .map(pvc -> VoteResultResponse.of(pvc, totalVotes))
+                .map(projectVoteCount -> VoteResultResponse.of(projectVoteCount, totalVotes))
                 .toList();
 
         return VoteResultsResponse.of(semester, results);
@@ -94,13 +96,12 @@ public class VoteService {
         List<ProjectVoteCount> latestVotes = ballotRepository.findPublicLatestBallots(latestSemester);
 
         if (latestVotes.isEmpty()) {
-            throw new IllegalArgumentException("[ERROR] 현재까지 투표가 진행된 적이 없습니다.");
+            throw new ResourceNotFoundException("공개된 투표 결과가 없습니다.");
         }
 
         long totalVotes = calculateTotalVotes(latestVotes);
-
         List<VoteResultResponse> results = latestVotes.stream()
-                .map(lv -> VoteResultResponse.of(lv, totalVotes))
+                .map(latestVote -> VoteResultResponse.of(latestVote, totalVotes))
                 .toList();
 
         return VoteResultsResponse.of(latestSemester, results);
@@ -108,12 +109,32 @@ public class VoteService {
 
     @Transactional(readOnly = true)
     public List<VoteParticipantsResponse> getParticipants(String semester) {
-        List<VoteParticipants> participants
-                = voteMetaRepository.findParticipantsProjectBySemester(semester);
-
-        return participants.stream().map(VoteParticipantsResponse::from).toList();
+        List<VoteParticipants> participants = voteMetaRepository.findParticipantsProjectBySemester(semester);
+        return participants.stream()
+                .map(VoteParticipantsResponse::from)
+                .toList();
     }
 
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+
+    private Role resolveUserRole(UserPrincipal userPrincipal) {
+        String role = userPrincipal.getUserRole()
+                .orElseThrow(() -> new ForbiddenException("사용자 권한 정보가 존재하지 않습니다."));
+        return Role.from(role);
+    }
+
+    private VoteMeta findVoteMeta(String semester) {
+        return voteMetaRepository.findBySemester(semester)
+                .orElseThrow(() -> new ResourceNotFoundException("투표를 찾을 수 없습니다."));
+    }
+
+    private VoteStatus findVoteStatus(String semester) {
+        return voteMetaRepository.findStatusBySemester(semester)
+                .orElseThrow(() -> new ResourceNotFoundException("투표를 찾을 수 없습니다."));
+    }
 
     private long calculateTotalVotes(List<ProjectVoteCount> projectVoteCounts) {
         return projectVoteCounts.stream()
@@ -124,7 +145,7 @@ public class VoteService {
     private void validateUserBallot(String semester, Long userId) {
         long votedCount = ballotRepository.countBallotsBySemesterAndUserId(semester, userId);
         if (votedCount >= 3) {
-            throw new IllegalArgumentException("[ERROR] 투표는 최대 3개까지 가능합니다.");
+            throw new BadRequestException("투표는 최대 3개까지 가능합니다.");
         }
     }
 
@@ -132,12 +153,12 @@ public class VoteService {
         Set<Long> participants = voteMetaRepository.findParticipantsByVoteMetaId(voteMetaId);
 
         Set<Long> invalidIds = projectIds.stream()
-                .filter(id -> !participants.contains(id))
+                .filter(projectId -> !participants.contains(projectId))
                 .collect(Collectors.toSet());
 
         if (!invalidIds.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "[ERROR] 투표에 참여하지 않는 프로젝트가 포함되어 있습니다. invalidProjectIds=" + invalidIds
+            throw new BadRequestException(
+                    "투표 대상이 아닌 프로젝트가 포함되어 있습니다. invalidProjectIds=" + invalidIds
             );
         }
     }
@@ -145,8 +166,7 @@ public class VoteService {
     private void validateResultVisibility(String semester) {
         boolean isPublic = voteMetaRepository.isResultPublic(semester);
         if (!isPublic) {
-            throw new IllegalArgumentException("[ERROR] 해당 투표 결과는 비공개입니다.");
+            throw new ForbiddenException("해당 투표 결과는 비공개입니다.");
         }
     }
-
 }

--- a/server/src/main/java/wap/web2/server/vote/service/VoteService.java
+++ b/server/src/main/java/wap/web2/server/vote/service/VoteService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +31,7 @@ import wap.web2.server.vote.dto.VoteResultsResponse;
 import wap.web2.server.vote.entity.Ballot;
 import wap.web2.server.vote.repository.BallotRepository;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VoteService {
@@ -51,7 +53,7 @@ public class VoteService {
 
         List<Long> projectIds = voteRequest.projectIds();
         validateUserBallot(semester, userId);
-        validateParticipatingProjects(projectIds, voteMeta.getId());
+        validateParticipatingProjects(semester, userId, projectIds, voteMeta.getId());
 
         for (Long projectId : projectIds) {
             ballotRepository.save(Ballot.of(semester, userId, userRole, projectId));
@@ -149,7 +151,7 @@ public class VoteService {
         }
     }
 
-    private void validateParticipatingProjects(List<Long> projectIds, Long voteMetaId) {
+    private void validateParticipatingProjects(String semester, Long userId, List<Long> projectIds, Long voteMetaId) {
         Set<Long> participants = voteMetaRepository.findParticipantsByVoteMetaId(voteMetaId);
 
         Set<Long> invalidIds = projectIds.stream()
@@ -157,9 +159,15 @@ public class VoteService {
                 .collect(Collectors.toSet());
 
         if (!invalidIds.isEmpty()) {
-            throw new BadRequestException(
-                    "투표 대상이 아닌 프로젝트가 포함되어 있습니다. invalidProjectIds=" + invalidIds
+            log.warn(
+                    "유효하지 않은 투표 대상이 포함되었습니다. semester={}, userId={}, requestProjectIds={}, invalidProjectIds={}, allowedProjectIds={}",
+                    semester,
+                    userId,
+                    projectIds,
+                    invalidIds,
+                    participants
             );
+            throw new BadRequestException("투표 대상이 아닌 프로젝트가 포함되어 있습니다.");
         }
     }
 


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
x

## 목적
서버 전반에 흩어져 있던 예외 처리 방식을 하나의 규약으로 통일하기 위한 작업입니다.

기존에는
- 컨트롤러별 `try-catch`
- 문자열 기반 에러 응답
- `@ResponseStatus`와 직접 상태 코드 반환 혼용
- Spring MVC 예외와 Security 예외의 분리된 처리
- 서비스 레이어의 `IllegalArgumentException` / 일반 예외 사용

등이 함께 존재해, 프론트엔드와 서버 모두 예외를 일관되게 해석하기 어려운 상태였습니다.

이번 PR에서는 예외를
- 공통 에러 코드
- 공통 응답 포맷
- 전역 예외 핸들러
- Security 예외 표준화
- 서비스 레이어의 의미 있는 예외
- 컨트롤러의 성공 응답 전담

구조로 정리해, 어디서 오류가 발생해도 같은 규약으로 응답되도록 맞췄습니다.

## 핵심 변경 사항

### 1. 공통 예외 모델 도입
- `ErrorCode`, `ErrorResponse`, `FieldErrorResponse`, `BusinessException`를 추가했습니다.
- 예외 응답이 `status`, `code`, `message`, `path`, `errors` 구조를 공통으로 갖도록 정리했습니다.
- `BadRequestException`, `ResourceNotFoundException` 등 기존 예외를 공통 체계에 편입했습니다.
- `ConflictException`, `ForbiddenException`, `InternalServerException`, `ProjectPasswordInvalidException`를 추가해 비즈니스 의미를 명확히 했습니다.

### 2. 전역 예외 처리 도입
- `GlobalExceptionHandler`를 추가해 MVC 계층 예외를 공통 `ErrorResponse`로 변환하도록 구성했습니다.
- validation, binding, 잘못된 요청 본문, 파라미터 누락, 쿠키 누락 등 입력 오류를 일관된 `400` 응답으로 매핑했습니다.
- 로그인 실패(`AuthenticationException`)도 공통 `401` 응답으로 처리되도록 보완했습니다.
- 미처리 예외는 표준 `500` 응답으로 수렴하도록 정리했습니다.

### 3. Security 예외 응답 표준화
- 인증 실패(401), 인가 실패(403)를 일반 API 예외와 동일한 포맷으로 통일했습니다.
- JWT 만료/위조/유효하지 않은 토큰을 공통 에러 코드로 구분할 수 있게 정리했습니다.
- OAuth2 로그인 실패도 기존 리다이렉트 흐름은 유지하면서 `code`, `message` 기준으로 표준화했습니다.

### 4. 서비스 레이어 예외 의미 정리
- 서비스가 `IllegalArgumentException`, `RuntimeException`, 문자열 분기 대신 의미 있는 예외를 직접 던지도록 변경했습니다.
- `찾을 수 없음`, `권한 없음`, `중복/충돌`, `현재 상태상 불가`, `잘못된 입력`을 구분해서 올리도록 정리했습니다.

### 5. 컨트롤러에서의 예외처리 코드 제거
- active 컨트롤러에서 broad `try-catch`와 직접 만든 에러 응답을 제거했습니다.
- 컨트롤러는 성공 응답만 작성하고, 실패는 전역 예외 처리로 넘기도록 정리했습니다.

### 6. 메시지 및 응답 톤 통일
- 사용자 노출 에러 메시지를 한국어 기준으로 통일했습니다.
- 사용자 응답에는 불필요한 내부 원인을 노출하지 않도록 정리하고, 필요한 상세 정보는 로그로 남기도록 보완했습니다.

### 7. 로깅 보완
- 일부 예외 상황은 서버 로그에서 상세 원인을 확인할 수 있도록 보강했습니다.
- `VoteService`의 잘못된 투표 대상 요청처럼 디버깅이 필요한 경우는 `warn` 로그로 상세 정보를 남기도록 했습니다.
- 직접 선언하던 `Logger`는 `@Slf4j` 기반으로 정리해 로깅 방식도 통일했습니다.

## 기대 효과
- 프론트엔드가 예외를 `status/code/message` 기준으로 일관되게 처리할 수 있습니다.
- 컨트롤러별 분기 로직이 줄어들어 유지보수성이 좋아집니다.
- 서비스 레이어에서 비즈니스 규칙 위반을 명확하게 표현할 수 있습니다.
- Security 예외와 일반 API 예외가 같은 규약으로 정렬됩니다.
- 사용자 메시지와 개발자용 로그의 역할이 분리되어 응답 품질과 디버깅 편의성이 함께 개선됩니다.

