### PR TITLE
feat: PR 변경 경로 기반 빌드 검증 GitHub Actions 추가

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,111 @@
+name: PR Build Validation
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  changes:
+    name: Detect Changed Areas
+    runs-on: ubuntu-latest
+    outputs:
+      client: ${{ steps.filter.outputs.client }}
+      server: ${{ steps.filter.outputs.server }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            client:
+              - 'client/**'
+            server:
+              - 'server/**'
+
+  client-build:
+    name: Client Build
+    needs: changes
+    if: ${{ needs.changes.outputs.client == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build client
+        run: npm run build
+
+  server-build:
+    name: Server Build
+    needs: changes
+    if: ${{ needs.changes.outputs.server == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Build server
+        run: ./gradlew bootJar -x test
+
+  pr-build-check:
+    name: PR Build Check
+    needs:
+      - changes
+      - client-build
+      - server-build
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate build results
+        shell: bash
+        run: |
+          client_changed="${{ needs.changes.outputs.client }}"
+          server_changed="${{ needs.changes.outputs.server }}"
+          client_result="${{ needs['client-build'].result }}"
+          server_result="${{ needs['server-build'].result }}"
+
+          echo "client changed: ${client_changed}"
+          echo "server changed: ${server_changed}"
+          echo "client build result: ${client_result}"
+          echo "server build result: ${server_result}"
+
+          if [[ "${client_changed}" == "true" && "${client_result}" != "success" ]]; then
+            echo "Client build was required but did not succeed."
+            exit 1
+          fi
+
+          if [[ "${server_changed}" == "true" && "${server_result}" != "success" ]]; then
+            echo "Server build was required but did not succeed."
+            exit 1
+          fi
+
+          echo "All required PR builds passed."


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- #issueNum

## 배경
Windows + Java 8 환경에서 종종 개발하기 때문에 테스트가 불가능합니다. java 버전을 업그레이드할 수 없는 상황이기 때문에 작성된 코드가 제대로 동작하는지 확인하기 어렵습니다.

이런 환경 차이로 인한 문제를 PR 단계에서 미리 확인할 수 있도록, 코드가 올라오면 GitHub Actions를 통해 변경된 영역의 빌드가 정상적으로 수행되는지 검증하는 작업을 추가했습니다.


## 작업 내용
- PR 전용 GitHub Actions 워크플로우를 추가했습니다.
- `dorny/paths-filter`를 사용해 변경된 패키지를 확인하고, 변경된 패키지에 대해서만 빌드를 테스트합니다.
  - 예를 들어 
    ```
    `client/**` 변경 시 프런트 빌드(`npm ci`, `npm run build`)가 실행
    `server/**` 변경 시 백엔드 빌드(`./gradlew bootJar -x test`)가 실행
    ```
- 마지막 `PR Build Check` Job에서 빌드 결과를 확인합니다.

## 기대 효과
- PR 단계에서 변경된 영역의 빌드 성공 여부를 자동으로 검증할 수 있습니다.
- 프런트/백엔드 변경이 없는 경우 불필요한 빌드를 줄일 수 있습니다.

## 확인 사항
- `client/**`만 변경된 PR: client-build만 실행
- `server/**`만 변경된 PR: server-build만 실행
- 둘 다 변경된 PR: 두 빌드 모두 실행
- 관련 없는 파일만 변경된 PR: 빌드 잡은 건너뛰고 최종 체크만 성공


