### PR TITLE
feat: 모니터링 중심 관측 기능 추가

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     // Swagger/OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
@@ -62,6 +63,8 @@ dependencies {
     // Monitor
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+    runtimeOnly 'io.opentelemetry:opentelemetry-exporter-otlp'
 
     // Cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/wap/web2/server/exception/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import wap.web2.server.observability.RequestCorrelation;
 
 @Slf4j
 @RestControllerAdvice
@@ -191,7 +192,12 @@ public class GlobalExceptionHandler {
     }
 
     private String extractRequestId(HttpServletRequest request) {
-        String requestId = request.getHeader("X-Request-Id");
+        Object requestIdAttribute = request.getAttribute(RequestCorrelation.REQUEST_ID_ATTRIBUTE);
+        if (requestIdAttribute instanceof String requestId && !requestId.isBlank()) {
+            return requestId;
+        }
+
+        String requestId = request.getHeader(RequestCorrelation.REQUEST_ID_HEADER);
         return requestId == null || requestId.isBlank() ? null : requestId;
     }
 }

--- a/server/src/main/java/wap/web2/server/observability/RequestCorrelation.java
+++ b/server/src/main/java/wap/web2/server/observability/RequestCorrelation.java
@@ -1,0 +1,11 @@
+package wap.web2.server.observability;
+
+public final class RequestCorrelation {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String REQUEST_ID_ATTRIBUTE = RequestCorrelation.class.getName() + ".requestId";
+    public static final String REQUEST_ID_MDC_KEY = "requestId";
+
+    private RequestCorrelation() {
+    }
+}

--- a/server/src/main/java/wap/web2/server/observability/RequestCorrelationFilter.java
+++ b/server/src/main/java/wap/web2/server/observability/RequestCorrelationFilter.java
@@ -1,0 +1,73 @@
+package wap.web2.server.observability;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import wap.web2.server.global.security.UserPrincipal;
+
+@Slf4j
+@Component
+public class RequestCorrelationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String requestId = resolveRequestId(request);
+        long startTime = System.nanoTime();
+        Throwable failure = null;
+
+        request.setAttribute(RequestCorrelation.REQUEST_ID_ATTRIBUTE, requestId);
+        response.setHeader(RequestCorrelation.REQUEST_ID_HEADER, requestId);
+        MDC.put(RequestCorrelation.REQUEST_ID_MDC_KEY, requestId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ServletException | IOException | RuntimeException exception) {
+            failure = exception;
+            throw exception;
+        } finally {
+            int status = failure == null ? response.getStatus() : HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+            long durationMs = (System.nanoTime() - startTime) / 1_000_000;
+
+            log.info(
+                    "http_request_completed method={} path={} status={} durationMs={} userId={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    status,
+                    durationMs,
+                    resolveUserId()
+            );
+
+            MDC.remove(RequestCorrelation.REQUEST_ID_MDC_KEY);
+        }
+    }
+
+    private String resolveRequestId(HttpServletRequest request) {
+        String requestId = request.getHeader(RequestCorrelation.REQUEST_ID_HEADER);
+        return requestId == null || requestId.isBlank() ? UUID.randomUUID().toString() : requestId;
+    }
+
+    private String resolveUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "anonymous";
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserPrincipal userPrincipal) {
+            return String.valueOf(userPrincipal.getId());
+        }
+
+        String name = authentication.getName();
+        return name == null || name.isBlank() ? "anonymous" : name;
+    }
+}

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -6,6 +6,7 @@ import static wap.web2.server.aws.AwsUtils.THUMBNAIL;
 import static wap.web2.server.util.SemesterGenerator.generateSemesterValue;
 import static wap.web2.server.util.SemesterGenerator.generateYearValue;
 
+import io.micrometer.observation.annotation.Observed;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +50,11 @@ public class ProjectService {
     // TODO: "비밀번호가 틀렸습니다." 를 반환하면 컨트롤러에서 401 에러를 내보내는데, 유연하지 못하다고 생각됩니다.
     @CacheEvict(value = "projectList", allEntries = true)
     @Transactional
+    @Observed(
+            name = "project.create",
+            contextualName = "project-create",
+            lowCardinalityKeyValues = {"operation", "project.create"}
+    )
     public String save(ProjectRequest request, UserPrincipal userPrincipal) throws IOException {
         if (request.getPassword() == null || !request.getPassword().equals(projectPassword)) {
             throw new ProjectPasswordInvalidException();
@@ -140,6 +146,11 @@ public class ProjectService {
 
     @CacheEvict(value = "projectList", allEntries = true)
     @Transactional
+    @Observed(
+            name = "project.update",
+            contextualName = "project-update",
+            lowCardinalityKeyValues = {"operation", "project.update"}
+    )
     public String update(Long projectId, ProjectRequest request, UserPrincipal userPrincipal) throws IOException {
         if (request.getPassword() == null || !request.getPassword().equals(projectPassword)) {
             throw new ProjectPasswordInvalidException();

--- a/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/ApplyService.java
@@ -2,6 +2,7 @@ package wap.web2.server.teambuild.service;
 
 import static wap.web2.server.util.SemesterGenerator.generateSemester;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +47,11 @@ public class ApplyService {
     private final UserRepository userRepository;
 
     @Transactional
+    @Observed(
+            name = "team_build.apply",
+            contextualName = "team-build-apply",
+            lowCardinalityKeyValues = {"operation", "team_build.apply"}
+    )
     public void apply(UserPrincipal userPrincipal, ProjectAppliesRequest request) {
         if (!isTeamApplyOpen()) {
             throw new ConflictException("현재 팀빌딩 상태에서는 지원할 수 없습니다.");
@@ -84,6 +90,11 @@ public class ApplyService {
     }
 
     @Transactional(readOnly = true)
+    @Observed(
+            name = "team_build.applies.read",
+            contextualName = "team-build-applies-read",
+            lowCardinalityKeyValues = {"operation", "team_build.applies.read"}
+    )
     public ProjectAppliesResponse getApplies(UserPrincipal userPrincipal, Long projectId) {
         User user = findUser(userPrincipal.getId());
         Project project = findProject(projectId);
@@ -108,6 +119,11 @@ public class ApplyService {
     }
 
     @Transactional
+    @Observed(
+            name = "team_build.preference",
+            contextualName = "team-build-preference",
+            lowCardinalityKeyValues = {"operation", "team_build.preference"}
+    )
     public void setPreference(UserPrincipal userPrincipal, RecruitmentDto request) {
         if (!isTeamRecruitOpen()) {
             throw new ConflictException("현재 팀빌딩 상태에서는 모집을 제출할 수 없습니다.");

--- a/server/src/main/java/wap/web2/server/teambuild/service/TeamBuildingResultService.java
+++ b/server/src/main/java/wap/web2/server/teambuild/service/TeamBuildingResultService.java
@@ -4,6 +4,7 @@ import static wap.web2.server.util.SemesterGenerator.generateSemester;
 import static wap.web2.server.util.SemesterGenerator.generateSemesterValue;
 import static wap.web2.server.util.SemesterGenerator.generateYearValue;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +35,11 @@ public class TeamBuildingResultService {
     private final ProjectApplyRepository projectApplyRepository;
 
     @Transactional(readOnly = true)
+    @Observed(
+            name = "team_build.results",
+            contextualName = "team-build-results",
+            lowCardinalityKeyValues = {"operation", "team_build.results"}
+    )
     public TeamBuildingResults getResults() {
         final String semester = generateSemester();
 

--- a/server/src/main/java/wap/web2/server/vote/service/VoteService.java
+++ b/server/src/main/java/wap/web2/server/vote/service/VoteService.java
@@ -2,6 +2,7 @@ package wap.web2.server.vote.service;
 
 import static wap.web2.server.util.SemesterGenerator.generateSemester;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,6 +42,11 @@ public class VoteService {
     private final VoteMetaRepository voteMetaRepository;
 
     @Transactional
+    @Observed(
+            name = "vote.submit",
+            contextualName = "vote-submit",
+            lowCardinalityKeyValues = {"operation", "vote.submit"}
+    )
     public void vote(UserPrincipal userPrincipal, VoteRequest voteRequest) {
         Long userId = userPrincipal.getId();
         Role userRole = resolveUserRole(userPrincipal);
@@ -77,6 +83,11 @@ public class VoteService {
 
     @Cacheable(value = "voteResults", key = "#semester")
     @Transactional(readOnly = true)
+    @Observed(
+            name = "vote.results",
+            contextualName = "vote-results",
+            lowCardinalityKeyValues = {"operation", "vote.results"}
+    )
     public VoteResultsResponse getVoteResults(String semester) {
         validateResultVisibility(semester);
 
@@ -92,6 +103,11 @@ public class VoteService {
 
     @Cacheable(value = "voteResults", key = "'latest'")
     @Transactional(readOnly = true)
+    @Observed(
+            name = "vote.results.latest",
+            contextualName = "vote-results-latest",
+            lowCardinalityKeyValues = {"operation", "vote.results.latest"}
+    )
     public VoteResultsResponse getMostRecentResults() {
         String currentSemester = generateSemester();
         String latestSemester = ballotRepository.findPublicLatestSemester(currentSemester, VoteStatus.ENDED);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -83,8 +83,22 @@ project:
 #  level:
 #    org.springframework.security: DEBUG
 
+logging:
+  include-application-name: false
+  pattern:
+    correlation: "[traceId=%X{traceId:-}, spanId=%X{spanId:-}, requestId=%X{requestId:-}] "
+
 ## monitoring
 management:
+  observations:
+    annotations:
+      enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${OTLP_TRACING_ENDPOINT:http://localhost:4318/v1/traces}
   endpoints:
     enabled-by-default: false
     web:

--- a/server/src/test/java/wap/web2/server/observability/RequestCorrelationFilterTest.java
+++ b/server/src/test/java/wap/web2/server/observability/RequestCorrelationFilterTest.java
@@ -1,0 +1,105 @@
+package wap.web2.server.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wap.web2.server.exception.GlobalExceptionHandler;
+import wap.web2.server.global.security.UserPrincipal;
+
+class RequestCorrelationFilterTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new TestController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .addFilters(new RequestCorrelationFilter())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void requestWithoutRequestIdGetsAssignedAndEchoedBack() throws Exception {
+        MvcResult result = mockMvc.perform(get("/test/ok"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(RequestCorrelation.REQUEST_ID_HEADER))
+                .andReturn();
+
+        assertThat(result.getResponse().getHeader(RequestCorrelation.REQUEST_ID_HEADER)).isNotBlank();
+    }
+
+    @Test
+    void requestWithRequestIdKeepsSameHeaderValue() throws Exception {
+        mockMvc.perform(get("/test/ok").header(RequestCorrelation.REQUEST_ID_HEADER, "req-123"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(RequestCorrelation.REQUEST_ID_HEADER, "req-123"));
+    }
+
+    @Test
+    void failingRequestIncludesSameRequestIdInHeaderAndBody() throws Exception {
+        MvcResult result = mockMvc.perform(get("/test/fail"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(header().exists(RequestCorrelation.REQUEST_ID_HEADER))
+                .andExpect(jsonPath("$.requestId").exists())
+                .andReturn();
+
+        String headerRequestId = result.getResponse().getHeader(RequestCorrelation.REQUEST_ID_HEADER);
+
+        assertThat(headerRequestId).isNotBlank();
+        assertThat(result.getResponse().getContentAsString()).contains(headerRequestId);
+    }
+
+    @Test
+    void requestLoggingDoesNotFailForAuthenticatedRequests() throws Exception {
+        UserPrincipal principal = new UserPrincipal(
+                7L,
+                "tester@example.com",
+                "password",
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                principal.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        mockMvc.perform(get("/test/ok"))
+                .andExpect(status().isOk());
+    }
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/test/ok")
+        ResponseEntity<String> ok() {
+            return ResponseEntity.ok("ok");
+        }
+
+        @GetMapping("/test/fail")
+        ResponseEntity<String> fail() {
+            throw new IllegalStateException("boom");
+        }
+    }
+}


### PR DESCRIPTION
## ✨ PR 세부 내용
<!-- 수정/추가한 내용을 적어주세요. -->
Prometheus와 Loki 기반 분석 흐름 위에 요청 상관관계와 기본 tracing 설정을 추가했습니다. 
주요 성능 병목 후보 서비스에 관측 포인트를 넣어 API 및 비즈니스 흐름을 추적할 수 있게 구성했습니다. 에러 응답과 애플리케이션 로그에 동일한 requestId를 남기도록 정리했습니다.

캐시 없는 환경에서 테스트하기 위해 `test` 브랜치에 우선적으로 머지하겠습니다.

## 👀 확인해주세요!


## ⌛ 소요 시간
