### PR TITLE
feat: project post시 버튼 비활성화

### DIFF
--- a/client/src/components/ProjectCreation/ProjectFormNew.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.js
@@ -323,7 +323,11 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
         type="submit"
         className={styles.submit_button}
         disabled={uploading || isSubmitting}
-        style={{ marginTop: "20px", marginBottom: "100px", cursor: "pointer" }}
+        style={{
+          marginTop: "20px",
+          marginBottom: "100px",
+          cursor: isSubmitting ? "not-allowed" : "pointer",
+        }}
       >
         {isSubmitting ? "업로드 중..." : isEdit ? "프로젝트 수정" : "프로젝트 생성"}
       </button>

--- a/client/src/components/ProjectCreation/ProjectFormNew.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
 import { projectApi } from "../../api/project";
-import Cookies from "js-cookie";
 import styles from "../../assets/ProjectCreation/ProjectForm.module.css";
 import useProjectForm from "../../hooks/ProjectCreation/useProjectForm";
 import ImageUploader from "./ImageUploader";
@@ -63,7 +62,6 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
     handleRemoveImage,
     handleMemberNameFocus,
     handleMemberNameChange,
-    handleMemberImageUpload,
     handleRoleChange,
     addTeamMember,
     handleRemoveTeamMember,
@@ -298,16 +296,12 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
             member={member}
             index={index}
             handleMemberNameChange={handleMemberNameChange}
-            handleMemberImageUpload={handleMemberImageUpload}
             handleRoleChange={handleRoleChange}
             handleMemberNameFocus={handleMemberNameFocus}
             roleOptions={roleOptions}
-            handleImgUpload={handleImgUpload}
-            errorMessage={errorMessage}
             addTeamMember={addTeamMember}
             handleRemoveTeamMember={handleRemoveTeamMember}
             teamMembers={teamMembers}
-            setTeamMembers={setTeamMembers}
           />
         ))}
       </div>

--- a/client/src/components/ProjectCreation/ProjectFormNew.js
+++ b/client/src/components/ProjectCreation/ProjectFormNew.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
 import { projectApi } from "../../api/project";
@@ -33,6 +33,7 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
   const { projectId } = useParams();
   const maxImageCount = 4; // 최대 이미지 업로드 개수
   const navigate = useNavigate(); // navigate 함수
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const {
     title,
     setTitle,
@@ -103,10 +104,14 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (isSubmitting) return;
+
     if (!password) {
       alert("비밀번호를 입력해 주세요.");
       return;
     }
+
+    setIsSubmitting(true);
 
     const formData = new FormData();
     const projectData = {
@@ -161,6 +166,8 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
         // console.error("에러 응답 코드:", error.response.status);
         // console.error("에러 메시지:", error.response.data);
       }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -168,7 +175,12 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
     <form
       className={`${styles.project_form} ${styles.mount1}`}
       onSubmit={handleSubmit}
+      aria-busy={isSubmitting}
     >
+      <fieldset
+        disabled={isSubmitting}
+        style={{ border: 0, margin: 0, padding: 0, minInlineSize: 0 }}
+      >
       <ImageUploader
         imgText={"메인 이미지 등록"}
         imgName={thumbnail}
@@ -316,11 +328,12 @@ const ProjectFormNew = ({ isEdit = false, existingProject = null }) => {
       <button
         type="submit"
         className={styles.submit_button}
-        disabled={uploading}
+        disabled={uploading || isSubmitting}
         style={{ marginTop: "20px", marginBottom: "100px", cursor: "pointer" }}
       >
-        {isEdit ? "프로젝트 수정" : "프로젝트 생성"}
+        {isSubmitting ? "업로드 중..." : isEdit ? "프로젝트 수정" : "프로젝트 생성"}
       </button>
+      </fieldset>
     </form>
   );
 };

--- a/client/src/components/ProjectCreation/TeamMemberInputForm.js
+++ b/client/src/components/ProjectCreation/TeamMemberInputForm.js
@@ -9,9 +9,7 @@ const TeamMemberInputForm = ({
   handleMemberNameFocus,
   roleOptions,
   addTeamMember,
-  handleMemberImageUpload,
   teamMembers,
-  setTeamMembers,
   handleRemoveTeamMember,
 }) => (
   <div className={styles.teammember}>


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- x

## ✨ PR 세부 내용
<!-- 수정/추가한 내용을 적어주세요. -->
- 프로젝트 생성하는 요청에서 시간이 1초~2초 걸리는데, 이때 버튼 비활성화하는 기능 추가했습니다.
- 서버단에서도 `서버 업로드 최적화(병렬 업로드 or presigned URL 직업로드)`와 `멱등키`작업 해볼 수 있을 듯 합니다. 지금은 간단하게 ui만 수정합니다.


## 👀 확인해주세요!


## ⌛ 소요 시간
