### PR TITLE
feat: Azure Blob Storage 에 이미지 업로드/삭제 기능

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,23 +89,24 @@ jobs:
               --restart unless-stopped \
               -p 8080:8080 \
               -v /opt/waps/oci:/home/app/.oci:ro \
-              -e DB_HOST=${{ secrets.DB_HOST }} \
-              -e DB_PORT=3306 \
-              -e DB_NAME=${{ secrets.DB_NAME }} \
-              -e DB_USER=${{ secrets.DB_USER }} \
-              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-              -e JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }} \
-              -e KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY }} \
-              -e SERVER_URL=${{ secrets.SERVER_URL }} \
-              -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
-              -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
-              -e AWS_S3_BUCKET_NAME=${{ secrets.AWS_S3_BUCKET_NAME }} \
-              -e AWS_REGION=${{ secrets.AWS_REGION }} \
-              -e OCI_NAMESPACE=${{ secrets.OCI_NAMESPACE }} \
-              -e OCI_BUCKET_NAME=${{ secrets.OCI_BUCKET_NAME }} \
-              -e OCI_REGION=${{ secrets.OCI_REGION }} \
-              -e OCI_CONFIG_PATH=/home/app/.oci/config \
-              -e SWAGGER_SERVER_URL=${{ secrets.SWAGGER_SERVER_URL }} \
+              -e "DB_HOST=${{ secrets.DB_HOST }}" \
+              -e "DB_PORT=3306" \
+              -e "DB_NAME=${{ secrets.DB_NAME }}" \
+              -e "DB_USER=${{ secrets.DB_USER }}" \
+              -e "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" \
+              -e "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" \
+              -e "KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY }}" \
+              -e "SERVER_URL=${{ secrets.SERVER_URL }}" \
+              -e "AZURE_STORAGE_CONNECTION_STRING=${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}" \
+              -e "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}" \
+              -e "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}" \
+              -e "AWS_S3_BUCKET_NAME=${{ secrets.AWS_S3_BUCKET_NAME }}" \
+              -e "AWS_REGION=${{ secrets.AWS_REGION }}" \
+              -e "OCI_NAMESPACE=${{ secrets.OCI_NAMESPACE }}" \
+              -e "OCI_BUCKET_NAME=${{ secrets.OCI_BUCKET_NAME }}" \
+              -e "OCI_REGION=${{ secrets.OCI_REGION }}" \
+              -e "OCI_CONFIG_PATH=/home/app/.oci/config" \
+              -e "SWAGGER_SERVER_URL=${{ secrets.SWAGGER_SERVER_URL }}" \
               "$IMAGE"
 
             echo "Waiting for application to start..."

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     implementation 'com.oracle.oci.sdk:oci-java-sdk-objectstorage:3.67.1'
     implementation 'com.oracle.oci.sdk:oci-java-sdk-common:3.67.1'
     implementation 'com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey3:3.67.1'
+
+    // Azure Storage
+    implementation 'com.azure:azure-storage-blob:12.32.0'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       # OAuth2
       KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY}
       SERVER_URL: ${SERVER_URL:-http://localhost:8080}
+      # Azure Blob Storage
+      AZURE_STORAGE_CONNECTION_STRING: ${AZURE_STORAGE_CONNECTION_STRING}
       # AWS S3
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}

--- a/server/src/main/java/wap/web2/server/config/azure/AzureBlobConfig.java
+++ b/server/src/main/java/wap/web2/server/config/azure/AzureBlobConfig.java
@@ -1,0 +1,35 @@
+package wap.web2.server.config.azure;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AzureStorageProperties.class)
+@RequiredArgsConstructor
+public class AzureBlobConfig {
+
+    private final AzureStorageProperties properties;
+
+    @Bean
+    public BlobServiceClient blobServiceClient() {
+        return new BlobServiceClientBuilder()
+                .connectionString(properties.getConnectionString())
+                .buildClient();
+    }
+
+    @Bean
+    public BlobContainerClient blobContainerClient(
+            BlobServiceClient blobServiceClient
+    ) {
+        BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(
+                properties.getContainerName()
+        );
+        containerClient.createIfNotExists();
+        return containerClient;
+    }
+}

--- a/server/src/main/java/wap/web2/server/config/azure/AzureStorageProperties.java
+++ b/server/src/main/java/wap/web2/server/config/azure/AzureStorageProperties.java
@@ -1,0 +1,16 @@
+package wap.web2.server.config.azure;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+
+@Getter
+@Setter
+@Profile("azure")
+@ConfigurationProperties(prefix = "azure.storage")
+public class AzureStorageProperties {
+
+    private String connectionString;
+    private String containerName;
+}

--- a/server/src/main/java/wap/web2/server/storage/impl/AzureStorageService.java
+++ b/server/src/main/java/wap/web2/server/storage/impl/AzureStorageService.java
@@ -1,0 +1,119 @@
+package wap.web2.server.storage.impl;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import wap.web2.server.storage.ObjectStorageService;
+import wap.web2.server.storage.StoragePathUtils;
+
+@Service
+@Profile("azure")
+@RequiredArgsConstructor
+public class AzureStorageService implements ObjectStorageService {
+
+    private static final String AZURE_BLOB_URL_SEPARATOR = ".blob.core.windows.net/";
+    private static final long MAX_FILE_SIZE = 100L * 1024 * 1024;
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp", "bmp");
+
+    private final BlobContainerClient blobContainerClient;
+
+    @Override
+    public List<String> uploadImages(
+            String dirName,
+            Integer projectYear,
+            Integer semester,
+            String projectName,
+            String imageType,
+            List<MultipartFile> imageFiles
+    ) throws IOException {
+        List<String> imageUrls = new ArrayList<>();
+        for (MultipartFile imageFile : imageFiles) {
+            imageUrls.add(uploadImage(dirName, projectYear, semester, projectName, imageType, imageFile));
+        }
+        return imageUrls;
+    }
+
+    @Override
+    public String uploadImage(
+            String dirName,
+            Integer projectYear,
+            Integer semester,
+            String projectName,
+            String imageType,
+            MultipartFile imageFile
+    ) throws IOException {
+        validateImage(imageFile);
+
+        String originalFileName = getOriginalFileName(imageFile);
+        String blobName = StoragePathUtils.createTimestampFileName(
+                dirName, projectYear, semester, projectName, imageType, originalFileName
+        );
+
+        BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+
+        BlobHttpHeaders headers = new BlobHttpHeaders().setContentType(imageFile.getContentType());
+        blobClient.uploadWithResponse(
+                new BlobParallelUploadOptions(imageFile.getInputStream())
+                        .setHeaders(headers),
+                null,
+                null
+        );
+
+        return blobClient.getBlobUrl();
+    }
+
+    @Override
+    public void deleteImage(String imageUrl) {
+        String blobName = extractBlobNameFromUrl(imageUrl);
+        blobContainerClient.getBlobClient(blobName).delete();
+    }
+
+    private void validateImage(MultipartFile imageFile) {
+        if (imageFile.isEmpty()) {
+            throw new IllegalArgumentException("[ERROR] 파일이 비어있습니다.");
+        }
+        if (imageFile.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("[ERROR] 파일 용량이 제한(100MB)을 초과했습니다.");
+        }
+        String originalFilename = getOriginalFileName(imageFile);
+        int dotIdx = originalFilename.lastIndexOf('.');
+        if (dotIdx == -1) {
+            throw new IllegalArgumentException("[ERROR] 파일 확장자가 없습니다: " + originalFilename);
+        }
+        String extension = originalFilename.substring(dotIdx + 1).toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new IllegalArgumentException("[ERROR] 지원하지 않는 이미지 확장자입니다: " + extension);
+        }
+    }
+
+    private String extractBlobNameFromUrl(String url) {
+        // URL format: https://{account}.blob.core.windows.net/{container}/{blobName}
+        int separatorIdx = url.indexOf(AZURE_BLOB_URL_SEPARATOR);
+        if (separatorIdx == -1) {
+            throw new IllegalArgumentException("[ERROR] 올바르지 않은 Azure Blob URL: " + url);
+        }
+        String afterDomain = url.substring(separatorIdx + AZURE_BLOB_URL_SEPARATOR.length());
+        int blobNameStart = afterDomain.indexOf('/');
+        if (blobNameStart == -1) {
+            throw new IllegalArgumentException("[ERROR] 올바르지 않은 Azure Blob URL: " + url);
+        }
+        return afterDomain.substring(blobNameStart + 1);
+    }
+
+    private String getOriginalFileName(MultipartFile multipartFile) {
+        String originalFilename = multipartFile.getOriginalFilename();
+        if (originalFilename == null) {
+            throw new IllegalArgumentException("[ERROR] 파일 이름이 없습니다.");
+        }
+        return originalFilename;
+    }
+}

--- a/server/src/main/resources/application-azure.yml
+++ b/server/src/main/resources/application-azure.yml
@@ -1,0 +1,4 @@
+azure:
+  storage:
+    connection-string: ${AZURE_STORAGE_CONNECTION_STRING}
+    container-name: images

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -49,7 +49,7 @@ spring:
     baseline-version: 1
 
   profiles:
-    active: aws
+    active: azure
 
 app:
   auth:


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- #588

## ✨ PR 세부 내용
### 기본 개념
Blob: Binary Large Object 준말. 스토리지에 저장되는 파일 하나임
Container: Blob을 담는 공간. 폴더라고 생각하면 됨.
Storage Account: Azure Storage 서비스를 사용하기 위한 최상위 계정

### 필요한 의존성

```gradle
implementation platform("com.azure:azure-sdk-bom:1.2.37") // optional
implementation "com.azure:azure-storage-blob"
implementation "com.azure:azure-identity"    // optional
```

### 구현 방식
이전 처럼 백엔드에서 Azure Blob에 직접 업로드하는 방식으로 구현했습니다. SAS URL, PreSigned URL 등 방법이 있는거 같은데, 투표 행사가 얼마 안남았기에 기능을 빠르게 복구하는데 초점을 두겠습니다.

`AzureBlobSotrageService`에 업로드 기능을 작성하였습니다. 원래는 `AzureBlobStorageUploader`에 업로드 기능을 넣고, `AzureBlobStorageService`가 `Uploader`에 의존하며, `StorageService`엔 파일 검증, 이미지 압축/리사이징 등을 넣으면 좋겠다고 생각했으나.. 같은 이유로 이것도 미루도록 하죠.. 


### 계정 보안 및 인증 방식
기본적으로 스토리지를 사용하기 위해 Azure 계정 권한이 필요합니다. Azure에서 계정을 인증하는 방식은 두 가지가 있습니다.

1. Connection String
2. azure-identity를 통한 `DefaultAzureCredential` 사용

1번은 간단하지만 보안 사고에 취약, 2번은 복잡하지만 보안에 강하다는 느낌이 드시나요.. 1번은 키를 환경변수를 통해 주입해 인증하는 방식이고, 2번은 키를 사용하지 않고 배포 환경(혹은 로컬 환경)에서 인프라적인 설정을 통해 인증하는 방식입니다. 2번이 너무 복잡하고 과해보여서 1번을 택했습니다.


## 👀 확인해주세요!
Azure Blob Storage Free tier는 읽기가 1만회? 정도로 기억합니다. 정말 운이 좋게도(?) 이 기록을 뚫게 된다면 기분 좋게 돈을 내겠죠...?

그런데 기왕 쓸거 프리티어 내에서 쓰면 기분이 두배로 좋으니까 이를 해결할 방법을 좀 찾아봤습니다. (일단 이미지는 public으로 해두었습니다. 즉, 누구나 url만 있다면 이미지에 접근 가능합니다.)

브라우저에 cache control이라는게 있더군요. 정적 리소스에 대한 캐싱인것 같은데, blob storage api 호출을 줄이는 가장 최선의 방법인 것 같습니다. 하지만 "캐시"이다 보니 데이터 정합성 문제도 있고, 캐시가 무력화되었을 때 어떻게 되는지 등등 더 알아봐야할 거 같아서 이번엔 skip했습니다


#### 배포, 테스트
로컬에서 postman으로 테스트해봤을 때 정상적으로 동작했습니다. 
배포 시엔 환경변수만 주입해주면 될거 같아요.

## ⌛ 소요 시간
3-4h