### PR TITLE
fix: 프로젝트 이미지 삭제/추가 에러

### DIFF
--- a/server/src/main/java/wap/web2/server/project/entity/Project.java
+++ b/server/src/main/java/wap/web2/server/project/entity/Project.java
@@ -12,8 +12,11 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -61,15 +64,19 @@ public class Project {
     @Column(length = 1000)
     private String thumbnail;
 
+    @Builder.Default
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Image> images = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Comment> comments = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     List<TeamMember> teamMembers = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     List<TechStack> techStacks = new ArrayList<>();
 
@@ -121,6 +128,18 @@ public class Project {
             this.images.add(image);
             image.updateImage(this); // 연관관계 양쪽 매핑
         }
+    }
+
+    public List<String> removeImages(Collection<String> imageUrls) {
+        Set<String> removalTargets = new HashSet<>(imageUrls);
+        List<String> removedImageUrls = this.images.stream()
+                .filter(image -> removalTargets.contains(image.getImageFile()))
+                .map(Image::getImageFile)
+                .toList();
+
+        this.images.removeIf(image -> removalTargets.contains(image.getImageFile()));
+
+        return removedImageUrls;
     }
 
     public boolean isOwner(User user) {

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -27,7 +27,6 @@ import wap.web2.server.project.dto.response.ProjectDetailsResponse;
 import wap.web2.server.project.dto.response.ProjectInfoResponse;
 import wap.web2.server.project.entity.Image;
 import wap.web2.server.project.entity.Project;
-import wap.web2.server.project.repository.ImageRepository;
 import wap.web2.server.project.repository.ProjectRepository;
 import wap.web2.server.storage.ObjectStorageService;
 import wap.web2.server.teambuild.dto.response.ProjectTemplate;
@@ -39,7 +38,6 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
-    private final ImageRepository imageRepository;
     private final ObjectStorageService objectStorageService;
 
     @Value("${project.password}")
@@ -174,11 +172,11 @@ public class ProjectService {
             project.updateThumbnail(thumbnailUrl);
         }
 
-        // 기존 프로젝트의 이미지 삭제 (행 없앰), null-safe
+        // 기존 프로젝트의 이미지 삭제
         log.info("[프로젝트 수정] ({})의 삭제 요청된 이미지 삭제", project.getTitle());
-        for (String imageUrl : request.getRemoval()) {
+        List<String> removedImageUrls = project.removeImages(getRemovalTargets(request));
+        for (String imageUrl : removedImageUrls) {
             log.info("[프로젝트 수정] 삭제하려는 image url: {}", imageUrl);
-            imageRepository.deleteByImageFile(imageUrl);
             objectStorageService.deleteImage(imageUrl);
         }
 
@@ -231,6 +229,14 @@ public class ProjectService {
     private Project findProject(Long projectId) {
         return projectRepository.findById(projectId)
                 .orElseThrow(() -> new ResourceNotFoundException("프로젝트를 찾을 수 없습니다."));
+    }
+
+    private List<String> getRemovalTargets(ProjectRequest request) {
+        if (request.getRemoval() == null) {
+            return Collections.emptyList();
+        }
+
+        return request.getRemoval();
     }
 
 }

--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -16,6 +16,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import wap.web2.server.exception.ForbiddenException;
 import wap.web2.server.exception.ProjectPasswordInvalidException;
 import wap.web2.server.exception.ResourceNotFoundException;
@@ -54,20 +55,21 @@ public class ProjectService {
 
         User user = findUser(userPrincipal.getId());
 
+        List<MultipartFile> imageFiles = getNonEmptyImageFiles(request);
         List<String> imageUrls = Collections.emptyList();
-        if (request.getImageFiles() != null) {
+        if (!imageFiles.isEmpty()) {
             imageUrls = objectStorageService.uploadImages(
                     PROJECT_DIR,
                     request.getProjectYear(),
                     request.getSemester(),
                     request.getTitle(),
                     IMAGES,
-                    request.getImageFiles()
+                    imageFiles
             );
         }
 
         String thumbnailUrl = "";
-        if (request.getThumbnailFiles() != null) {
+        if (hasFile(request.getThumbnailFiles())) {
             thumbnailUrl = objectStorageService.uploadImage(
                     PROJECT_DIR,
                     request.getProjectYear(),
@@ -159,7 +161,7 @@ public class ProjectService {
         }
 
         // 썸네일 이미지가 없으면 유지 or 있으면 변경
-        if (request.getThumbnailFiles() != null) {
+        if (hasFile(request.getThumbnailFiles())) {
             log.info("[프로젝트 수정] ({})의 thumbnail 이미지 변경", project.getTitle());
             String thumbnailUrl = objectStorageService.uploadImage(
                     PROJECT_DIR,
@@ -181,7 +183,8 @@ public class ProjectService {
         }
 
         // 추가 이미지를 Project에 삽입, 만약 ImageS3가 null이라면 skip
-        if (request.getImageFiles() != null && !request.getImageFiles().isEmpty()) {
+        List<MultipartFile> imageFiles = getNonEmptyImageFiles(request);
+        if (!imageFiles.isEmpty()) {
             log.info("[프로젝트 수정] ({})에 이미지 추가", project.getTitle());
             List<String> imageUrls = objectStorageService.uploadImages(
                     PROJECT_DIR,
@@ -189,7 +192,7 @@ public class ProjectService {
                     request.getSemester(),
                     request.getTitle(),
                     IMAGES,
-                    request.getImageFiles()
+                    imageFiles
             );
             List<Image> images = Image.listOf(imageUrls);
             project.addAllImage(images);
@@ -237,6 +240,20 @@ public class ProjectService {
         }
 
         return request.getRemoval();
+    }
+
+    private List<MultipartFile> getNonEmptyImageFiles(ProjectRequest request) {
+        if (request.getImageFiles() == null) {
+            return Collections.emptyList();
+        }
+
+        return request.getImageFiles().stream()
+                .filter(this::hasFile)
+                .toList();
+    }
+
+    private boolean hasFile(MultipartFile file) {
+        return file != null && !file.isEmpty();
     }
 
 }

--- a/server/src/main/java/wap/web2/server/storage/impl/AzureStorageService.java
+++ b/server/src/main/java/wap/web2/server/storage/impl/AzureStorageService.java
@@ -5,6 +5,7 @@ import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobHttpHeaders;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -20,7 +21,7 @@ import wap.web2.server.storage.StoragePathUtils;
 @RequiredArgsConstructor
 public class AzureStorageService implements ObjectStorageService {
 
-    private static final String AZURE_BLOB_URL_SEPARATOR = ".blob.core.windows.net/";
+    private static final String AZURE_BLOB_HOST_SUFFIX = ".blob.core.windows.net";
     private static final long MAX_FILE_SIZE = 100L * 1024 * 1024;
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "webp", "bmp");
 
@@ -97,16 +98,23 @@ public class AzureStorageService implements ObjectStorageService {
 
     private String extractBlobNameFromUrl(String url) {
         // URL format: https://{account}.blob.core.windows.net/{container}/{blobName}
-        int separatorIdx = url.indexOf(AZURE_BLOB_URL_SEPARATOR);
-        if (separatorIdx == -1) {
+        URI uri = URI.create(url);
+        String host = uri.getHost();
+        if (host == null || !host.endsWith(AZURE_BLOB_HOST_SUFFIX)) {
             throw new IllegalArgumentException("[ERROR] 올바르지 않은 Azure Blob URL: " + url);
         }
-        String afterDomain = url.substring(separatorIdx + AZURE_BLOB_URL_SEPARATOR.length());
-        int blobNameStart = afterDomain.indexOf('/');
-        if (blobNameStart == -1) {
+
+        String path = uri.getPath();
+        if (path == null || path.isBlank()) {
             throw new IllegalArgumentException("[ERROR] 올바르지 않은 Azure Blob URL: " + url);
         }
-        return afterDomain.substring(blobNameStart + 1);
+
+        String containerPrefix = "/" + blobContainerClient.getBlobContainerName() + "/";
+        if (!path.startsWith(containerPrefix)) {
+            throw new IllegalArgumentException("[ERROR] 올바르지 않은 Azure Blob URL: " + url);
+        }
+
+        return path.substring(containerPrefix.length());
     }
 
     private String getOriginalFileName(MultipartFile multipartFile) {

--- a/server/src/main/java/wap/web2/server/storage/impl/S3ObjectStorageService.java
+++ b/server/src/main/java/wap/web2/server/storage/impl/S3ObjectStorageService.java
@@ -1,6 +1,7 @@
 package wap.web2.server.storage.impl;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +20,6 @@ import wap.web2.server.storage.StoragePathUtils;
 @Profile("aws")
 @RequiredArgsConstructor
 public class S3ObjectStorageService implements ObjectStorageService {
-
-    private static final String S3_URL_DOMAIN = ".amazonaws.com/";
-    private static final int S3_DOMAIN_LENGTH = S3_URL_DOMAIN.length();
 
     private final S3Client s3Client;
     private final S3Properties s3Properties;
@@ -83,11 +81,13 @@ public class S3ObjectStorageService implements ObjectStorageService {
     }
 
     private String extractKeyFromUrl(String url) {
-        int idx = url.indexOf(S3_URL_DOMAIN);
-        if (idx == -1) {
+        URI uri = URI.create(url);
+        String path = uri.getPath();
+        if (path == null || path.length() <= 1) {
             throw new IllegalArgumentException("[ERROR] 올바르지 않은 S3 URL: " + url);
         }
-        return url.substring(idx + S3_DOMAIN_LENGTH);
+
+        return path.substring(1);
     }
 
     private String getOriginalFileName(MultipartFile multipartFile) {

--- a/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
@@ -1,0 +1,144 @@
+package wap.web2.server.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import wap.web2.server.global.security.UserPrincipal;
+import wap.web2.server.member.entity.User;
+import wap.web2.server.member.repository.UserRepository;
+import wap.web2.server.project.dto.TeamMemberDto;
+import wap.web2.server.project.dto.TechStackDto;
+import wap.web2.server.project.dto.request.ProjectRequest;
+import wap.web2.server.project.entity.Image;
+import wap.web2.server.project.entity.Project;
+import wap.web2.server.project.repository.ProjectRepository;
+import wap.web2.server.storage.ObjectStorageService;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    ProjectRepository projectRepository;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    ObjectStorageService objectStorageService;
+
+    @InjectMocks
+    ProjectService projectService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(projectService, "projectPassword", "pw");
+    }
+
+    @Test
+    void removal이_없어도_프로젝트_수정은_성공한다() throws Exception {
+        // given
+        User owner = owner();
+        UserPrincipal principal = principal(owner.getId());
+        Project project = project(owner);
+
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(projectRepository.findById(project.getProjectId())).thenReturn(Optional.of(project));
+
+        ProjectRequest request = baseRequestBuilder()
+                .removal(null)
+                .build();
+
+        // when
+        String result = projectService.update(project.getProjectId(), request, principal);
+
+        // then
+        assertThat(result).isEqualTo("수정되었습니다.");
+        assertThat(project.getTitle()).isEqualTo("updated title");
+        verify(objectStorageService, never()).deleteImage(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 삭제_요청된_이미지는_프로젝트_컬렉션에서_제거하고_스토리지에서도_삭제한다() throws Exception {
+        // given
+        User owner = owner();
+        UserPrincipal principal = principal(owner.getId());
+        Project project = project(owner);
+        project.addAllImage(Image.listOf(List.of("https://cdn.example.com/a.png", "https://cdn.example.com/b.png")));
+
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(projectRepository.findById(project.getProjectId())).thenReturn(Optional.of(project));
+
+        ProjectRequest request = baseRequestBuilder()
+                .removal(List.of("https://cdn.example.com/a.png", "https://cdn.example.com/missing.png"))
+                .build();
+
+        // when
+        projectService.update(project.getProjectId(), request, principal);
+
+        // then
+        assertThat(project.getImages())
+                .extracting(Image::getImageFile)
+                .containsExactly("https://cdn.example.com/b.png");
+        verify(objectStorageService).deleteImage("https://cdn.example.com/a.png");
+        verify(objectStorageService, never()).deleteImage("https://cdn.example.com/missing.png");
+    }
+
+    private ProjectRequest.ProjectRequestBuilder baseRequestBuilder() {
+        return ProjectRequest.builder()
+                .title("updated title")
+                .projectType("WEB")
+                .content("updated content")
+                .summary("updated summary")
+                .semester(1)
+                .projectYear(2026)
+                .password("pw")
+                .teamMember(List.of(TeamMemberDto.builder()
+                        .memberName("member")
+                        .memberRole("backend")
+                        .build()))
+                .techStack(List.of(TechStackDto.builder()
+                        .techStackName("Spring")
+                        .techStackType("BACKEND")
+                        .build()));
+    }
+
+    private User owner() {
+        User user = new User();
+        user.setId(1L);
+        user.setName("owner");
+        return user;
+    }
+
+    private UserPrincipal principal(Long userId) {
+        UserPrincipal principal = mock(UserPrincipal.class);
+        when(principal.getId()).thenReturn(userId);
+        return principal;
+    }
+
+    private Project project(User owner) {
+        return Project.builder()
+                .projectId(10L)
+                .user(owner)
+                .title("old title")
+                .projectType("WEB")
+                .content("old content")
+                .summary("old summary")
+                .semester(1)
+                .projectYear(2026)
+                .images(new ArrayList<>())
+                .teamMembers(new ArrayList<>())
+                .techStacks(new ArrayList<>())
+                .build();
+    }
+}

--- a/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import wap.web2.server.global.security.UserPrincipal;
 import wap.web2.server.member.entity.User;
@@ -66,6 +67,46 @@ class ProjectServiceTest {
         assertThat(result).isEqualTo("수정되었습니다.");
         assertThat(project.getTitle()).isEqualTo("updated title");
         verify(objectStorageService, never()).deleteImage(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void 빈_파일_part는_첨부되지_않은_파일로_취급한다() throws Exception {
+        // given
+        User owner = owner();
+        UserPrincipal principal = principal(owner.getId());
+        Project project = project(owner);
+
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(projectRepository.findById(project.getProjectId())).thenReturn(Optional.of(project));
+
+        ProjectRequest request = baseRequestBuilder()
+                .removal(null)
+                .build();
+        request.setMultipartFiles(
+                new MockMultipartFile("thumbnail", "", "image/png", new byte[0]),
+                List.of(new MockMultipartFile("image", "", "image/png", new byte[0]))
+        );
+
+        // when
+        projectService.update(project.getProjectId(), request, principal);
+
+        // then
+        verify(objectStorageService, never()).uploadImage(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any()
+        );
+        verify(objectStorageService, never()).uploadImages(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyList()
+        );
     }
 
     @Test


### PR DESCRIPTION
<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- #issueNum

## ✨ PR 세부 내용

프로젝트 수정 시 이미지 삭제/추가 흐름에서 발생하던 정합성 문제와 빈 파일 multipart 요청 처리 문제를 개선했습니다.

## 변경 사항

- `removal` 필드가 누락된 프로젝트 수정 요청을 null-safe 처리
- 이미지 삭제 시 `ImageRepository` bulk delete 대신 `Project.images` 컬렉션에서 제거하도록 변경
- `orphanRemoval`을 통해 프로젝트에 속한 이미지 row가 삭제되도록 수정
- Azure Blob URL 검증 및 blob name 추출 로직 보완
- S3/Azure 스토리지 객체 key를 URL path 기준으로 추출하도록 수정
- 빈 `image`, `thumbnail` multipart file part는 미첨부로 처리

#### chore
- Lombok builder 사용 시 `Project` 컬렉션 기본값이 유지되도록 `@Builder.Default` 적용
- 관련 회귀 테스트 추가

## 문제 원인

- 프로젝트 수정 요청에서 `removal`이 없으면 `request.getRemoval()`이 `null`이 되고, 이를 for-each로 순회하면서 예외가 발생했습니다.
- 기존 이미지 삭제는 JPQL bulk delete로 DB row를 직접 삭제했지만, 같은 트랜잭션 내 `Project.images` 컬렉션은 갱신되지 않아 JPA 영속성 컨텍스트와 DB 변경 의도가 어긋날 수 있었습니다.
- Postman/클라이언트에서 파일 key는 보내고 파일을 선택하지 않으면 빈 `MultipartFile`이 바인딩되며, 기존 로직은 이를 업로드 대상으로 처리해 Azure 이미지 검증에서 실패했습니다.

## 해결 방법

- 삭제 대상 이미지를 `Project.images` 컬렉션에서 제거하고, JPA `orphanRemoval`이 DB 삭제를 처리하도록 변경했습니다.
- `removal == null`이면 빈 리스트로 처리하도록 방어했습니다.
- 업로드 전 `MultipartFile`이 `null`이거나 `isEmpty()`인 경우 미첨부로 간주하도록 처리했습니다.
- Azure Blob URL은 host suffix를 검증한 뒤 path에서 blob name을 추출하도록 보완했습니다.


## 👀 확인해주세요!
브랜치를 파서 작업했는데 Intellij에서 실수로 `develop`브랜치로 push 해버렸습니다....ㅠㅠ 어쩔 수 없이 main으로 바로 pr작성해서 배포할게요


## ⌛ 소요 시간
1h 30m
