### PR TITLE
fix: 현재 스토리지에서 관리하지 않는 이미지 삭제 건너뛰기

### DIFF
--- a/server/src/main/java/wap/web2/server/project/service/ProjectService.java
+++ b/server/src/main/java/wap/web2/server/project/service/ProjectService.java
@@ -179,6 +179,10 @@ public class ProjectService {
         List<String> removedImageUrls = project.removeImages(getRemovalTargets(request));
         for (String imageUrl : removedImageUrls) {
             log.info("[프로젝트 수정] 삭제하려는 image url: {}", imageUrl);
+            if (!objectStorageService.supports(imageUrl)) {
+                log.info("[프로젝트 수정] 현재 스토리지에서 관리하지 않는 image url 이므로 물리 삭제를 건너뜁니다: {}", imageUrl);
+                continue;
+            }
             objectStorageService.deleteImage(imageUrl);
         }
 

--- a/server/src/main/java/wap/web2/server/storage/ObjectStorageService.java
+++ b/server/src/main/java/wap/web2/server/storage/ObjectStorageService.java
@@ -24,6 +24,8 @@ public interface ObjectStorageService {
             MultipartFile imageFile
     ) throws IOException;
 
+    boolean supports(String imageUrl);
+
     void deleteImage(String imageUrl);
 
 }

--- a/server/src/main/java/wap/web2/server/storage/impl/AzureStorageService.java
+++ b/server/src/main/java/wap/web2/server/storage/impl/AzureStorageService.java
@@ -78,6 +78,16 @@ public class AzureStorageService implements ObjectStorageService {
         blobContainerClient.getBlobClient(blobName).delete();
     }
 
+    @Override
+    public boolean supports(String imageUrl) {
+        try {
+            extractBlobNameFromUrl(imageUrl);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
     private void validateImage(MultipartFile imageFile) {
         if (imageFile.isEmpty()) {
             throw new IllegalArgumentException("[ERROR] 파일이 비어있습니다.");

--- a/server/src/main/java/wap/web2/server/storage/impl/OracleObjectStorageService.java
+++ b/server/src/main/java/wap/web2/server/storage/impl/OracleObjectStorageService.java
@@ -87,6 +87,17 @@ public class OracleObjectStorageService implements ObjectStorageService {
         objectStorageClient.deleteObject(deleteObjectRequest);
     }
 
+    @Override
+    public boolean supports(String imageUrl) {
+        try {
+            extractObjectNameFromUrl(imageUrl);
+            return imageUrl.contains("objectstorage." + properties.getRegion() + ".oraclecloud.com")
+                    && imageUrl.contains("/n/" + properties.getNamespace() + "/b/" + properties.getBucketName() + "/o/");
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
     private String getOriginalFileName(MultipartFile multipartFile) {
         String originalFilename = multipartFile.getOriginalFilename();
         if (originalFilename == null) {

--- a/server/src/main/java/wap/web2/server/storage/impl/S3ObjectStorageService.java
+++ b/server/src/main/java/wap/web2/server/storage/impl/S3ObjectStorageService.java
@@ -80,6 +80,17 @@ public class S3ObjectStorageService implements ObjectStorageService {
         s3Client.deleteObject(deleteRequest);
     }
 
+    @Override
+    public boolean supports(String imageUrl) {
+        try {
+            URI uri = URI.create(imageUrl);
+            String host = uri.getHost();
+            return host != null && host.startsWith(s3Properties.getS3().getBucketName() + ".s3.");
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
     private String extractKeyFromUrl(String url) {
         URI uri = URI.create(url);
         String path = uri.getPath();

--- a/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
+++ b/server/src/test/java/wap/web2/server/project/service/ProjectServiceTest.java
@@ -119,6 +119,7 @@ class ProjectServiceTest {
 
         when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
         when(projectRepository.findById(project.getProjectId())).thenReturn(Optional.of(project));
+        when(objectStorageService.supports("https://cdn.example.com/a.png")).thenReturn(true);
 
         ProjectRequest request = baseRequestBuilder()
                 .removal(List.of("https://cdn.example.com/a.png", "https://cdn.example.com/missing.png"))
@@ -133,6 +134,31 @@ class ProjectServiceTest {
                 .containsExactly("https://cdn.example.com/b.png");
         verify(objectStorageService).deleteImage("https://cdn.example.com/a.png");
         verify(objectStorageService, never()).deleteImage("https://cdn.example.com/missing.png");
+    }
+
+    @Test
+    void 현재_스토리지에서_관리하지_않는_이미지는_프로젝트_컬렉션에서만_제거한다() throws Exception {
+        // given
+        User owner = owner();
+        UserPrincipal principal = principal(owner.getId());
+        Project project = project(owner);
+        String legacyS3Url = "https://waps-bucket.s3.ap-northeast-2.amazonaws.com/projects/2025-2/test/image.png";
+        project.addAllImage(Image.listOf(List.of(legacyS3Url)));
+
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(projectRepository.findById(project.getProjectId())).thenReturn(Optional.of(project));
+        when(objectStorageService.supports(legacyS3Url)).thenReturn(false);
+
+        ProjectRequest request = baseRequestBuilder()
+                .removal(List.of(legacyS3Url))
+                .build();
+
+        // when
+        projectService.update(project.getProjectId(), request, principal);
+
+        // then
+        assertThat(project.getImages()).isEmpty();
+        verify(objectStorageService, never()).deleteImage(legacyS3Url);
     }
 
     private ProjectRequest.ProjectRequestBuilder baseRequestBuilder() {


### PR DESCRIPTION
- `ObjectStorageService`에 `supports`를 추가하여 현자 사용중인 스토리지 서비스가 책임지는 이미지인지 확인한 후 동작하도록 변경

<!--
1. PR 이름 컨벤션
feat: 투표 상태 관리에 필요한 api 개발

2. 라벨
작업 분야: server/client
작업 종류: feat/refactor/fix/...
    이름: 가나다/가나디/기니디/...
-->

##  📌 관련 이슈
- #issueNum

## ✨ PR 세부 내용
<!-- 수정/추가한 내용을 적어주세요. -->

## 발생한 문제

프로젝트 수정 과정에서 이미지를 삭제하거나 교체할 때 문제가 발생했습니다. 

현재 이미지 삭제는 다음 두 단계로 이뤄집니다.

1. DB에서 이미지 데이터 제거
2. Storage에서 실제 이미지 객체 삭제

그런데 운영 서버를 여러 번 이전하면서 Storage 공급자가 AWS에서 Azure로 변경되었습니다.  
이로 인해 DB에는 과거 AWS 이미지 URL이 남아 있지만, 현재 애플리케이션에서는 `AzureStorageService`가 활성화되어 있습니다.

이 상태에서 프로젝트를 수정하면서 기존 이미지를 삭제하면, `AzureStorageService`가 AWS 이미지 URL을 Azure Blob URL로 해석해 삭제하려고 합니다. 그 결과 URL 파싱 또는 삭제 과정에서 예외가 발생하고, 프로젝트 수정 전체가 실패합니다.

## 어떻게 해결할까요

현재 코드에는 "이미지 교체"라는 별도 의미가 없습니다.

프로젝트 수정 요청에서 이미지를 바꾸는 행위는 결국 다음 두 동작의 조합입니다.

1. 기존 이미지 제거
2. 새로운 이미지 추가

따라서 "이미지 교체" 여부를 별도로 판단해서 특별 처리하기보다는, 이미지 삭제 로직 자체를 안전하게 만드는 것이 더 적절하다고 판단했습니다.

즉, 삭제 대상 이미지가 현재 StorageService의 관할이면 실제 스토리지에서도 삭제하고,  
현재 StorageService가 처리할 수 없는 URL이면 DB에서만 제거하고 스토리지 삭제는 건너뛰도록 했습니다.

### 코덱스 의견

`StorageService`는 현재 활성화된 Storage 공급자에 대해서만 책임을 가져야 합니다.

예를 들어 `AzureStorageService`는 Azure Blob URL만 삭제할 수 있습니다.  
AWS URL을 Azure 서비스가 삭제하려고 하는 것은 책임 범위를 벗어난 동작입니다.

따라서 삭제 전에 해당 URL이 현재 StorageService가 관리할 수 있는 URL인지 확인하고,  
지원 가능한 URL일 때만 실제 스토리지 삭제를 수행하도록 했습니다.

이 방식은 다음 장점이 있습니다.

- 프로젝트 수정 기능이 과거 Storage 이전 이슈 때문에 실패하지 않습니다.
- 이미지 삭제 정책을 "삭제 + 추가"라는 현재 API 의미에 맞게 일관되게 유지할 수 있습니다.
- StorageService의 책임 범위를 명확히 할 수 있습니다.
- 과거 AWS 객체 정리는 프로젝트 수정 트랜잭션이 아니라 별도 cleanup 작업으로 분리할 수 있습니다.

## 수정 사항

- `ObjectStorageService`에 `supports(String imageUrl)` 메서드를 추가했습니다.
- `AzureStorageService`, `S3ObjectStorageService`, `OracleObjectStorageService`에서 각 Storage가 관리할 수 있는 URL인지 판단하도록 구현했습니다.
- `ProjectService.update()`에서 이미지 삭제 시 현재 StorageService가 지원하는 URL일 때만 `deleteImage()`를 호출하도록 변경했습니다.
- 현재 StorageService가 지원하지 않는 URL은 DB 이미지 목록에서는 제거하되, 실제 스토리지 삭제는 건너뛰도록 했습니다.
- 과거 AWS URL이 남아 있는 경우에도 프로젝트 수정이 성공하는 테스트를 추가했습니다.

## 동작 방식

```text
삭제 요청된 이미지 URL이 DB에 존재합니다.
-> DB 이미지 데이터는 제거합니다.
-> 현재 StorageService가 해당 URL을 지원하는지 확인합니다.
-> 지원하면 Storage 객체도 삭제합니다.
-> 지원하지 않으면 Storage 삭제는 건너뜁니다.
```

## 👀 확인해주세요!


## ⌛ 소요 시간
